### PR TITLE
chore: fix GitHub Action syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branch: main
+    branches: [main]
   pull_request:
-    branch: main
+    branches: [main]
 
 jobs:
   tests:

--- a/.github/workflows/spectral.yaml
+++ b/.github/workflows/spectral.yaml
@@ -1,8 +1,8 @@
 on:
   push:
-    branch: main
+    branches: [main]
   pull_request:
-    branch: main
+    branches: [main]
 
 jobs:
   spectral:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branch: main
+    branches: [main]
   pull_request:
-    branch: main
+    branches: [main]
 
 jobs:
   tests:


### PR DESCRIPTION
The previous syntax was incorrect, even if GitHub didn't
explicitly complain about it.