### PR TITLE
chore: use the correct name for the lint pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  tests:
+  linters:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Use the correct name, so we can identify it when it runs and set
it as required to merge.