### PR TITLE
feat(tests): add first support to integration tests

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -1,4 +1,4 @@
-package requests
+package common
 
 type Publisher struct {
 	URL         string `json:"url" validate:"required"`

--- a/internal/common/responses.go
+++ b/internal/common/responses.go
@@ -1,0 +1,9 @@
+package common
+
+type Response struct {
+	Data any `json:"data,omitempty"`
+}
+
+func NewResponse(data any) *Response {
+	return &Response{Data: data}
+}

--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -7,7 +7,6 @@ import (
 	"github.com/italia/developers-italia-api/internal/common"
 	"github.com/italia/developers-italia-api/internal/handlers/general"
 	"github.com/italia/developers-italia-api/internal/models"
-	"github.com/italia/developers-italia-api/internal/requests"
 	"gorm.io/gorm"
 )
 
@@ -81,7 +80,7 @@ func (p *Log) GetLog(ctx *fiber.Ctx) error {
 
 // PostLog creates a new log.
 func (p *Log) PostLog(ctx *fiber.Ctx) error {
-	logReq := new(requests.Log)
+	logReq := new(common.Log)
 
 	if err := ctx.BodyParser(&logReq); err != nil {
 		return common.Error(fiber.StatusBadRequest, "can't create Log", "invalid json")
@@ -102,7 +101,7 @@ func (p *Log) PostLog(ctx *fiber.Ctx) error {
 
 // PatchLog updates the log with the given ID.
 func (p *Log) PatchLog(ctx *fiber.Ctx) error {
-	logReq := new(requests.Log)
+	logReq := new(common.Log)
 
 	if err := ctx.BodyParser(logReq); err != nil {
 		return common.Error(fiber.StatusBadRequest, "can't update Log", "invalid json")

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/italia/developers-italia-api/internal/common"
 	"github.com/italia/developers-italia-api/internal/models"
-	"github.com/italia/developers-italia-api/internal/requests"
 	"gorm.io/gorm"
 )
 
@@ -41,7 +40,7 @@ func (p *Publisher) GetPublishers(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(&publishers)
+	return ctx.JSON(common.NewResponse(publishers))
 }
 
 // GetPublisher gets the publisher with the given ID and returns any error encountered.
@@ -61,7 +60,7 @@ func (p *Publisher) GetPublisher(ctx *fiber.Ctx) error {
 
 // PostPublisher creates a new publisher.
 func (p *Publisher) PostPublisher(ctx *fiber.Ctx) error {
-	request := requests.Publisher{}
+	request := common.Publisher{}
 
 	if err := ctx.BodyParser(&request); err != nil {
 		return common.Error(fiber.StatusBadRequest, "can't create Publisher", "invalid json", err)
@@ -83,12 +82,12 @@ func (p *Publisher) PostPublisher(ctx *fiber.Ctx) error {
 		return common.Error(fiber.StatusInternalServerError, "can't create Publisher", "db error")
 	}
 
-	return ctx.JSON(&publisher)
+	return ctx.JSON(common.NewResponse(publisher))
 }
 
 // PatchPublisher updates the publisher with the given ID.
 func (p *Publisher) PatchPublisher(ctx *fiber.Ctx) error {
-	publisherReq := new(requests.PublisherUpdate)
+	publisherReq := new(common.PublisherUpdate)
 
 	if err := ctx.BodyParser(publisherReq); err != nil {
 		return common.Error(fiber.StatusBadRequest, "can't update Publisher", "invalid json")
@@ -107,7 +106,7 @@ func (p *Publisher) PatchPublisher(ctx *fiber.Ctx) error {
 	return ctx.JSON(&publisher)
 }
 
-func (p *Publisher) updatePublisher(ctx *fiber.Ctx, publisher models.Publisher, req *requests.PublisherUpdate) error {
+func (p *Publisher) updatePublisher(ctx *fiber.Ctx, publisher models.Publisher, req *common.PublisherUpdate) error {
 	err := p.db.Transaction(func(gormTrx *gorm.DB) error {
 		if err := gormTrx.Model(&models.Publisher{}).
 			Preload("CodeHosting").

--- a/main_test.go
+++ b/main_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gofiber/fiber/v2"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,7 +29,6 @@ func TestEndpoints(t *testing.T) {
 		expectedCode        int
 		expectedBody        string
 		expectedContentType string
-		expectedData        fiber.Map
 		validateFunc        func(t *testing.T, data interface{})
 	}{
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -1,18 +1,22 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEndpoints(t *testing.T) {
-	// goodToken := "Bearer v2.local.TwwHUQEi8hr2Eo881_Bs5vK9dHOR5BgEU24QRf-U7VmUwI1yOEA6mFT0EsXioMkFT_T-jjrtIJ_Nv8f6hR6ifJXUOuzWEkm9Ijq1mqSjQatD3aDqKMyjjBA"
-	// badToken := "Bearer v2.local.UngfrCDNwGUw4pff2oBNoyxYvOErcbVVqLndl6nzONafUCzktaOeMSmoI7B0h62zoxXXLqTm_Phl"
+	goodToken := "Bearer v2.local.TwwHUQEi8hr2Eo881_Bs5vK9dHOR5BgEU24QRf-U7VmUwI1yOEA6mFT0EsXioMkFT_T-jjrtIJ_Nv8f6hR6ifJXUOuzWEkm9Ijq1mqSjQatD3aDqKMyjjBA"
+	badToken := "Bearer v2.local.UngfrCDNwGUw4pff2oBNoyxYvOErcbVVqLndl6nzONafUCzktaOeMSmoI7B0h62zoxXXLqTm_Phl"
 
 	tests := []struct {
 		description string
@@ -25,8 +29,10 @@ func TestEndpoints(t *testing.T) {
 
 		// Expected output
 		expectedCode        int
-		expectedBody        any
+		expectedBody        string
 		expectedContentType string
+		expectedData        fiber.Map
+		validateFunc        func(t *testing.T, data interface{})
 	}{
 		{
 			description: "publishers get route",
@@ -34,7 +40,7 @@ func TestEndpoints(t *testing.T) {
 			method:      "GET",
 
 			expectedCode:        200,
-			expectedBody:        "[]",
+			expectedBody:        "{\"data\":[]}",
 			expectedContentType: "application/json",
 		},
 		{
@@ -47,11 +53,12 @@ func TestEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 		},
 		{
-			description:         "publishers get non-existing id",
-			route:               "/v1/publishers/404",
-			method:              "GET",
-			expectedCode:        404,
-			expectedBody:        `{"title":"can't get Publisher","detail":"Publisher was not found","status":404}`,
+			description:  "publishers get non-existing id",
+			route:        "/v1/publishers/404",
+			method:       "GET",
+			expectedCode: 404,
+			expectedBody: `{"title":"can't get Publisher","detail":"Publisher was not found","status":404}`,
+
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -65,7 +72,7 @@ func TestEndpoints(t *testing.T) {
 		},
 
 		// Publishers
-		/*{
+		{
 			description: "POST publisher",
 			route:       "/v1/publishers",
 			method:      "POST",
@@ -74,8 +81,19 @@ func TestEndpoints(t *testing.T) {
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
-			expectedCode:        200,
-			expectedBody:        `{"email":"example@example.com","description":"","CodeHosting":[{"ID":1,"url":"https://www.example.com"}]}`,
+			expectedCode: 200,
+			validateFunc: func(t *testing.T, data interface{}) {
+				f, ok := data.(map[string]interface{})
+				if !ok {
+					t.Error(t, fmt.Errorf("expected map[string]interface{}, got %T", data))
+				}
+				fMap := f["data"].(map[string]interface{})
+				codeHost := fMap["codeHosting"].([]interface{})
+				assert.Equal(t, 1, len(codeHost))
+				codeHostElement := codeHost[0].(map[string]interface{})
+				assert.Equal(t, codeHostElement["url"], "https://www.example.com")
+				assert.Equal(t, fMap["email"], "example@example.com")
+			},
 			expectedContentType: "application/json",
 		},
 		{
@@ -90,7 +108,7 @@ func TestEndpoints(t *testing.T) {
 			expectedCode:        401,
 			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
-		},*/
+		},
 	}
 
 	os.Remove("./test.db")
@@ -116,16 +134,25 @@ func TestEndpoints(t *testing.T) {
 			}
 
 			res, err := app.Test(req, -1)
-
 			assert.Nil(t, err)
 
 			assert.Equal(t, test.expectedCode, res.StatusCode)
 
 			body, err := ioutil.ReadAll(res.Body)
+			assert.Nil(t, err)
 
 			assert.Nil(t, err)
 
-			assert.Equal(t, test.expectedBody, string(body))
+			if test.validateFunc != nil {
+				var bodyMap interface{}
+				err = json.Unmarshal(body, &bodyMap)
+				assert.Nil(t, err)
+				test.validateFunc(t, bodyMap)
+			}
+
+			if test.expectedBody != "" {
+				assert.Equal(t, test.expectedBody, string(body))
+			}
 
 			assert.Equal(t, test.expectedContentType, res.Header.Get("Content-Type"))
 		})


### PR DESCRIPTION
This PR introduces integration tests through GO and Fiber.
A few considerations:

* expectedBody was kept at the end. Implement a tests with strings and JSONs leads a lot of codes and errors due to strict go typing rules.
* In case of a custom validation needed, a "validateFunc" was introduced.