### PR TITLE
chore: increase golangci-lint-action timeout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,5 @@ jobs:
         with:
           go-version: 1.18.x
       - uses: golangci/golangci-lint-action@v3
+        with:
+          args: --timeout 3m --verbose


### PR DESCRIPTION
Increase golangci-lint-action timeout because the action takes a
more than 1 minute to run on GitHub's servers (https://github.com/golangci/golangci-lint-action/issues/297).

Enable verbose mode as well, so we can understand what's going on.