### PR TITLE
fix: remove unused transaction

### DIFF
--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -34,9 +34,7 @@ func NewLog(db *gorm.DB) *Log {
 func (p *Log) GetLogs(ctx *fiber.Ctx) error {
 	var logs []models.Log
 
-	stmt := p.db.Begin()
-
-	stmt, err := general.Clauses(ctx, stmt, "message")
+	stmt, err := general.Clauses(ctx, p.db, "message")
 	if err != nil {
 		return common.Error(
 			fiber.StatusUnprocessableEntity,


### PR DESCRIPTION
Transactions in gorm need to be explicitly finalized with Commit() or
Rollback(), otherwise they'll keep the connection in use. This is not
really clear in the docs.

Remove the transaction in /logs, as we don't need it anyway.

Fix #109.