### PR TITLE
feat: make limiter work behind proxy and disable it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ endpoints at `http://localhost:3000/v1/`.
 
 The application will automatically reload when a change is made.
 
+# Configuration
+
+You can configure the API with environment variables:
+
+* `MAX_REQUESTS` (optional): number of requests per minute after which responses
+  will be ratelimited.
+  Default: no limit.
+
 # Contributing
 
 This project exists also thanks to your contributions! Here is a list of people

--- a/internal/common/env.go
+++ b/internal/common/env.go
@@ -8,7 +8,7 @@ import (
 type Base64Key [SymmetricKeyLen]byte
 
 type Environment struct {
-	MaxRequests        int        `env:"MAX_REQUESTS" envDefault:"20"`
+	MaxRequests        int        `env:"MAX_REQUESTS" envDefault:"0"`
 	CurrentEnvironment string     `env:"ENVIRONMENT" envDefault:"local"`
 	Database           string     `env:"DATABASE_DSN"`
 	PasetoKey          *Base64Key `env:"PASETO_KEY"`

--- a/main.go
+++ b/main.go
@@ -60,10 +60,13 @@ func Setup() *fiber.App {
 	app.Use(recover.New())
 
 	// Use Fiber Rate API Limiter
-	if !envs.IsTest() {
+	if !envs.IsTest() && envs.MaxRequests != 0 {
 		app.Use(limiter.New(limiter.Config{
 			Max:               envs.MaxRequests,
 			LimiterMiddleware: limiter.SlidingWindow{},
+			KeyGenerator: func(ctx *fiber.Ctx) string {
+				return ctx.IP() + ctx.Get(fiber.HeaderXForwardedFor, "")
+			},
 		}))
 	}
 


### PR DESCRIPTION
The limiter is kinda naive, so let's disable it by default.
When enabled, make it work with proxies (which it's also the scenario
internal our deployment, with the k8s ingress).