### PR TITLE
fix: handle bool saving in POSTs

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -4,7 +4,7 @@ type Publisher struct {
 	CodeHosting []CodeHosting `json:"codeHosting" validate:"required"`
 	Description string        `json:"description"`
 	Email       string        `json:"email" validate:"email"`
-	Active      bool          `json:"active"`
+	Active      *bool         `json:"active"`
 }
 
 type CodeHosting struct {
@@ -14,7 +14,7 @@ type CodeHosting struct {
 type Software struct {
 	URLs          []string `json:"urls" validate:"required,gt=0,dive,url"`
 	PubliccodeYml string   `json:"publiccodeYml" validate:"required"`
-	Active        bool     `json:"active"`
+	Active        *bool    `json:"active"`
 }
 
 type Log struct {

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -92,8 +92,9 @@ func (p *Publisher) PostPublisher(ctx *fiber.Ctx) error {
 	}
 
 	publisher := &models.Publisher{
-		ID:    utils.UUIDv4(),
-		Email: request.Email,
+		ID:     utils.UUIDv4(),
+		Email:  request.Email,
+		Active: request.Active,
 	}
 
 	for _, URLAddress := range request.CodeHosting {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -34,7 +34,7 @@ type Publisher struct {
 	Email       string         `json:"email"`
 	Description string         `json:"description"`
 	CodeHosting []CodeHosting  `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;unique"`
-	Active      bool           `json:"active" gorm:"default:true"`
+	Active      *bool          `json:"active" gorm:"default:true;not null"`
 	CreatedAt   time.Time      `json:"createdAt" gorm:"index"`
 	UpdatedAt   time.Time      `json:"updatedAt"`
 	DeletedAt   gorm.DeletedAt `json:"-" gorm:"index"`
@@ -66,7 +66,7 @@ type Software struct {
 	URLs          []SoftwareURL  `json:"urls"`
 	PubliccodeYml string         `json:"publiccodeYml"`
 	Logs          []Log          `json:"-" gorm:"polymorphic:Entity;"`
-	Active        bool           `json:"active" gorm:"default:true"`
+	Active        *bool          `json:"active" gorm:"default:true;not null"`
 	CreatedAt     time.Time      `json:"createdAt" gorm:"index"`
 	UpdatedAt     time.Time      `json:"updatedAt"`
 	DeletedAt     gorm.DeletedAt `json:"-" gorm:"index"`

--- a/main_test.go
+++ b/main_test.go
@@ -447,6 +447,8 @@ func TestPublishersEndpoints(t *testing.T) {
 				_, err = time.Parse(time.RFC3339, response["updatedAt"].(string))
 				assert.Nil(t, err)
 
+				assert.Equal(t, true, response["active"])
+
 				// TODO: check the record was actually created in the database
 				// TODO: check there are no dangling publishers_codeHosting
 			},
@@ -487,6 +489,20 @@ func TestPublishersEndpoints(t *testing.T) {
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Publisher`, response["title"])
 				assert.Equal(t, "invalid json", response["detail"])
+			},
+		},
+		{
+			description: "POST publishers with optional boolean field set to false",
+			query:       "POST /v1/publishers",
+			body:        `{"active": false, "codeHosting": [{"url" : "https://www.example.com"}], "email":"example@example.com"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, false, response["active"])
 			},
 		},
 		{
@@ -1293,6 +1309,8 @@ func TestSoftwareEndpoints(t *testing.T) {
 				_, err = time.Parse(time.RFC3339, response["updatedAt"].(string))
 				assert.Nil(t, err)
 
+				assert.Equal(t, true, response["active"])
+
 				// TODO: check the record was actually created in the database
 				// TODO: check there are no dangling software_urls
 			},
@@ -1351,6 +1369,20 @@ func TestSoftwareEndpoints(t *testing.T) {
 		// 		assert.Equal(t, "invalid json", response["detail"])
 		// 	},
 		// },
+		{
+			description: "POST software with optional boolean field set to false",
+			query:       "POST /v1/software",
+			body:        `{"active": false, "urls":["https://example.org"], "publiccodeYml": "-"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, false, response["active"])
+			},
+		},
 		{
 			description: "POST software with validation errors",
 			query:       "POST /v1/software",


### PR DESCRIPTION
GORM doesn't save fields with zero values:
https://gorm.io/docs/create.html#Default-Values

We don't want map based saving (https://gorm.io/docs/create.html#Create-From-Map) because that doesn't support hooks and associations.