### PR TITLE
fix: make Publisher email optional

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -5,7 +5,7 @@ import "strings"
 type PublisherPost struct {
 	CodeHosting  []CodeHosting `json:"codeHosting" validate:"required,gt=0,dive"`
 	Description  string        `json:"description" validate:"required"`
-	Email        string        `json:"email" validate:"email,required"`
+	Email        *string       `json:"email" validate:"omitempty,email"`
 	Active       *bool         `json:"active"`
 	ExternalCode string        `json:"externalCode" validate:"max=255"`
 }
@@ -46,6 +46,11 @@ type Webhook struct {
 	Secret string `json:"secret"`
 }
 
-func NormalizeEmail(email string) string {
-	return strings.TrimSpace(strings.ToLower(email))
+func NormalizeEmail(email *string) *string {
+	if email == nil {
+		return nil
+	}
+
+	normalized := strings.TrimSpace(strings.ToLower(*email))
+	return &normalized
 }

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -52,5 +52,6 @@ func NormalizeEmail(email *string) *string {
 	}
 
 	normalized := strings.TrimSpace(strings.ToLower(*email))
+
 	return &normalized
 }

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -175,7 +175,7 @@ func (p *Publisher) updatePublisherTrx(
 	}
 
 	if request.Email != "" {
-		normalizedEmail := common.NormalizeEmail(request.Email)
+		normalizedEmail := common.NormalizeEmail(&request.Email)
 		publisher.Email = normalizedEmail
 	}
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -31,7 +31,7 @@ type Log struct {
 
 type Publisher struct {
 	ID           string         `json:"id" gorm:"primaryKey"`
-	Email        string         `json:"email"`
+	Email        *string        `json:"email,omitempty"`
 	Description  string         `json:"description" gorm:"uniqueIndex;not null"`
 	CodeHosting  []CodeHosting  `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;unique"`
 	Active       *bool          `json:"active" gorm:"default:true;not null"`

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -124,12 +124,14 @@ func TestPublisherCreate(t *testing.T) {
 	loadFixtures(t, "publishers.yml")
 	description := "New publisher"
 
+	email := "new-publisher@example.org"
+
 	// New ID
 	err := db.Create(
 		&Publisher{
 			ID:          utils.UUIDv4(),
 			Description: description,
-			Email:       "new-publisher@example.org",
+			Email:       &email,
 		},
 	).Error
 	assert.NoError(t, err)
@@ -139,7 +141,7 @@ func TestPublisherCreate(t *testing.T) {
 		&Publisher{
 			ID:          "2ded32eb-c45e-4167-9166-a44e18b8adde",
 			Description: description,
-			Email:       "new-publisher@example.org",
+			Email:       &email,
 		},
 	).Error
 	assert.EqualError(t, err, "UNIQUE constraint failed: publishers.description")


### PR DESCRIPTION
Publisher's email is just a way to reach a referent person for the publisher, so it's acceptable for different publishers to have the same contact.