### PR TITLE
fix: publisher conflict message

### DIFF
--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -124,7 +124,7 @@ func (p *Publisher) PostPublisher(ctx *fiber.Ctx) error {
 		case common.ErrDBUniqueConstraint:
 			return common.Error(fiber.StatusConflict,
 				"can't create Publisher",
-				"Publisher with provided description, email, alternativeId or CodeHosting URL already exists")
+				"description, alternativeId or codeHosting URL already exists")
 		default:
 			return common.Error(fiber.StatusInternalServerError,
 				"can't create Publisher",

--- a/main_test.go
+++ b/main_test.go
@@ -477,7 +477,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"Publisher with provided description, email, alternativeId or CodeHosting URL already exists","status":409}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST publisher with empty alternativeId",
@@ -528,7 +528,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"Publisher with provided description, email, alternativeId or CodeHosting URL already exists","status":409}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST new publisher with an existing email",
@@ -596,7 +596,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"Publisher with provided description, email, alternativeId or CodeHosting URL already exists","status":409}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST new publisher with no description",
@@ -632,7 +632,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"Publisher with provided description, email, alternativeId or CodeHosting URL already exists","status":409}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST publishers with invalid payload",


### PR DESCRIPTION
Remove `email` from the conflict message as it's no longer a unique field.