### PR TITLE
fix: don't soft delete resources

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -31,15 +31,14 @@ type Log struct {
 }
 
 type Publisher struct {
-	ID            string         `json:"id" gorm:"primaryKey"`
-	Email         *string        `json:"email,omitempty"`
-	Description   string         `json:"description" gorm:"uniqueIndex;not null"`
-	CodeHosting   []CodeHosting  `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;unique"`
-	Active        *bool          `json:"active" gorm:"default:true;not null"`
-	AlternativeID *string        `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
-	CreatedAt     time.Time      `json:"createdAt" gorm:"index"`
-	UpdatedAt     time.Time      `json:"updatedAt"`
-	DeletedAt     gorm.DeletedAt `json:"-" gorm:"index"`
+	ID            string        `json:"id" gorm:"primaryKey"`
+	Email         *string       `json:"email,omitempty"`
+	Description   string        `json:"description" gorm:"uniqueIndex;not null"`
+	CodeHosting   []CodeHosting `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;unique"`
+	Active        *bool         `json:"active" gorm:"default:true;not null"`
+	AlternativeID *string       `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
+	CreatedAt     time.Time     `json:"createdAt" gorm:"index"`
+	UpdatedAt     time.Time     `json:"updatedAt"`
 }
 
 func (Publisher) TableName() string {
@@ -55,13 +54,12 @@ func (CodeHosting) TableName() string {
 }
 
 type CodeHosting struct {
-	ID          string         `json:"-" gorm:"primaryKey"`
-	URL         string         `json:"url" gorm:"not null;uniqueIndex"`
-	Group       *bool          `json:"group" gorm:"default:true;not null"`
-	PublisherID string         `json:"-"`
-	CreatedAt   time.Time      `json:"createdAt" gorm:"index"`
-	UpdatedAt   time.Time      `json:"updatedAt"`
-	DeletedAt   gorm.DeletedAt `json:"-" gorm:"index"`
+	ID          string    `json:"-" gorm:"primaryKey"`
+	URL         string    `json:"url" gorm:"not null;uniqueIndex"`
+	Group       *bool     `json:"group" gorm:"default:true;not null"`
+	PublisherID string    `json:"-"`
+	CreatedAt   time.Time `json:"createdAt" gorm:"index"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 type Software struct {
@@ -103,12 +101,11 @@ func (su SoftwareURL) MarshalJSON() ([]byte, error) {
 }
 
 type Webhook struct {
-	ID        string         `json:"id" gorm:"primaryKey"`
-	URL       string         `json:"url" gorm:"index:idx_webhook_url,unique"`
-	Secret    string         `json:"-"`
-	CreatedAt time.Time      `json:"createdAt" gorm:"index"`
-	UpdatedAt time.Time      `json:"updatedAt"`
-	DeletedAt gorm.DeletedAt `json:"-" gorm:"index"`
+	ID        string    `json:"id" gorm:"primaryKey"`
+	URL       string    `json:"url" gorm:"index:idx_webhook_url,unique"`
+	Secret    string    `json:"-"`
+	CreatedAt time.Time `json:"createdAt" gorm:"index"`
+	UpdatedAt time.Time `json:"updatedAt"`
 
 	// Entity this Webhook is for (fe. Publisher, Software, etc.)
 	EntityID   string `json:"-" gorm:"index:idx_webhook_url,unique"`


### PR DESCRIPTION
Don't soft delete API resources with unique columns, otherwise it wouldn't be possible to add a previously used (and deleted) resource, because is would still be in the database, albeit invisible to the API users.