### PR TITLE
chore(ci): always tag for Goreleaser with a valid semantic version

### DIFF
--- a/.github/workflows/publish-staging-docker-image.yml
+++ b/.github/workflows/publish-staging-docker-image.yml
@@ -32,7 +32,7 @@ jobs:
 
       -
         # Tag with a temporary valid semantic version. This is required by goreleaser.
-        run: git tag $(git describe --tags --abbrev=0)-main-$(git rev-parse --short HEAD)
+        run: git tag v0-main-$(git rev-parse --short HEAD)
 
       -
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
The last tag can be a non valid semantic version (fe. when we tag with helm/vX.Y.Z), so let's force a valid semantic version for the temporary Goreleaser tag.