### PR TITLE
Generate "Detail" field for Validation Errors.

### DIFF
--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -20,8 +20,10 @@ func Error(status int, title string, detail string) ProblemJSONError {
 }
 
 func ErrorWithValidationErrors(
-	status int, title string, detail string, validationErrors []ValidationError,
+	status int, title string, validationErrors []ValidationError,
 ) ProblemJSONError {
+	detail := GenerateErrorDetails(validationErrors)
+
 	return ProblemJSONError{Title: title, Detail: detail, Status: status, ValidationErrors: validationErrors}
 }
 

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -17,7 +17,6 @@ const (
 
 type ValidationError struct {
 	Field string `json:"field"`
-	Rule  string `json:"rule"`
 	Value string `json:"value,omitempty"`
 }
 
@@ -51,7 +50,6 @@ func ValidateStruct(validateStruct interface{}) []ValidationError {
 
 			validationErrors = append(validationErrors, ValidationError{
 				Field: err.Field(),
-				Rule:  err.Tag(),
 				Value: value,
 			})
 		}

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -19,7 +19,7 @@ const (
 type ValidationError struct {
 	Field string `json:"field"`
 	Value string `json:"value,omitempty"`
-	Rule   string `json:"rule"`
+	Rule  string `json:"rule"`
 }
 
 func ValidateStruct(validateStruct interface{}) []ValidationError {
@@ -53,7 +53,7 @@ func ValidateStruct(validateStruct interface{}) []ValidationError {
 			validationErrors = append(validationErrors, ValidationError{
 				Field: err.Field(),
 				Value: value,
-				Rule: err.Tag(),
+				Rule:  err.Tag(),
 			})
 		}
 	}
@@ -80,18 +80,18 @@ func GenerateErrorDetails(validationErrors []ValidationError) string {
 
 	for _, validationError := range validationErrors {
 		switch validationError.Rule {
-			case "required":
-				errors = append(errors, fmt.Sprintf("%s is required", validationError.Field))
-			case "email":
-				errors = append(errors, fmt.Sprintf("%s is not a valid email", validationError.Field))
-			case "min":
-				errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too short)", validationError.Field))
-			case "max":
-				errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too long)", validationError.Field))
-			case "gt":
-				errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too few items)", validationError.Field))
-			default:
-				errors = append(errors, fmt.Sprintf("%s is invalid", validationError.Field))
+		case "required":
+			errors = append(errors, fmt.Sprintf("%s is required", validationError.Field))
+		case "email":
+			errors = append(errors, fmt.Sprintf("%s is not a valid email", validationError.Field))
+		case "min":
+			errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too short)", validationError.Field))
+		case "max":
+			errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too long)", validationError.Field))
+		case "gt":
+			errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too few items)", validationError.Field))
+		default:
+			errors = append(errors, fmt.Sprintf("%s is invalid", validationError.Field))
 		}
 	}
 

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -43,6 +43,11 @@ func ValidateStruct(validateStruct interface{}) []ValidationError {
 				value = ""
 			}
 
+			valueRunes := []rune(value)
+			if len(valueRunes) > maxProvidedValue {
+				value = string(valueRunes[:maxProvidedValue])
+			}
+
 			validationErrors = append(validationErrors, ValidationError{
 				Field: err.Field(),
 				Value: value,
@@ -76,7 +81,7 @@ func ValidateRequestEntity(ctx *fiber.Ctx, request interface{}, errorMessage str
 		}
 
 		errorDetails := strings.Join(errors, ", ")
-		
+
 		return ErrorWithValidationErrors(
 			fiber.StatusUnprocessableEntity, errorMessage, errorDetails, err,
 		)

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -19,6 +19,7 @@ const (
 type ValidationError struct {
 	Field string `json:"field"`
 	Value string `json:"value,omitempty"`
+	Tag   string `json:"tag"`
 }
 
 func ValidateStruct(validateStruct interface{}) []ValidationError {
@@ -52,6 +53,7 @@ func ValidateStruct(validateStruct interface{}) []ValidationError {
 			validationErrors = append(validationErrors, ValidationError{
 				Field: err.Field(),
 				Value: value,
+				Tag: err.Tag(),
 			})
 		}
 	}
@@ -77,23 +79,19 @@ func GenerateErrorDetails(validationErrors []ValidationError) string {
 	var errors []string
 
 	for _, validationError := range validationErrors {
-		switch validationError.Field {
-			case "codeHosting":
-				errors = append(errors, "codeHosting is required and should contain at least an 'url' object")
-			case "url":
-				errors = append(errors, "url is not a valid url")
-			case "alternativeId":
-				errors = append(errors, "alternativeId does not respect its size limits (1-255)")
-			case "description":
-				errors = append(errors, "description is required")
+		switch validationError.Tag {
+			case "required":
+				errors = append(errors, fmt.Sprintf("%s is required", validationError.Field))
 			case "email":
-				errors = append(errors, "email is not a valid email")
-			case "aliases":
-				errors = append(errors, "aliases must be an array of urls")
-			case "message": 
-				errors = append(errors, "message is required")
+				errors = append(errors, fmt.Sprintf("%s is not a valid email", validationError.Field))
+			case "min":
+				errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too short)", validationError.Field))
+			case "max":
+				errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too long)", validationError.Field))
+			case "gt":
+				errors = append(errors, fmt.Sprintf("%s does not meet its size limits (too few items)", validationError.Field))
 			default:
-				errors = append(errors, validationError.Field + " is not valid")
+				errors = append(errors, fmt.Sprintf("%s is invalid", validationError.Field))
 		}
 	}
 

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -18,8 +18,8 @@ const (
 
 type ValidationError struct {
 	Field string `json:"field"`
-	Value string `json:"value,omitempty"`
 	Rule  string `json:"rule"`
+	Value string `json:"value"`
 }
 
 func ValidateStruct(validateStruct interface{}) []ValidationError {
@@ -52,8 +52,8 @@ func ValidateStruct(validateStruct interface{}) []ValidationError {
 
 			validationErrors = append(validationErrors, ValidationError{
 				Field: err.Field(),
-				Value: value,
 				Rule:  err.Tag(),
+				Value: value,
 			})
 		}
 	}

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -19,7 +19,7 @@ const (
 type ValidationError struct {
 	Field string `json:"field"`
 	Value string `json:"value,omitempty"`
-	Tag   string `json:"tag"`
+	Rule   string `json:"rule"`
 }
 
 func ValidateStruct(validateStruct interface{}) []ValidationError {
@@ -53,7 +53,7 @@ func ValidateStruct(validateStruct interface{}) []ValidationError {
 			validationErrors = append(validationErrors, ValidationError{
 				Field: err.Field(),
 				Value: value,
-				Tag: err.Tag(),
+				Rule: err.Tag(),
 			})
 		}
 	}
@@ -79,7 +79,7 @@ func GenerateErrorDetails(validationErrors []ValidationError) string {
 	var errors []string
 
 	for _, validationError := range validationErrors {
-		switch validationError.Tag {
+		switch validationError.Rule {
 			case "required":
 				errors = append(errors, fmt.Sprintf("%s is required", validationError.Field))
 			case "email":

--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -91,7 +91,7 @@ func (p *Log) PostLog(ctx *fiber.Ctx) error {
 	}
 
 	if err := common.ValidateStruct(*logReq); err != nil {
-		return common.ErrorWithValidationErrors(fiber.StatusUnprocessableEntity, "can't create Log", "invalid format", err)
+		return common.ErrorWithValidationErrors(fiber.StatusUnprocessableEntity, "can't create Log", err)
 	}
 
 	log := models.Log{ID: utils.UUIDv4(), Message: logReq.Message}
@@ -112,7 +112,7 @@ func (p *Log) PatchLog(ctx *fiber.Ctx) error {
 	}
 
 	if err := common.ValidateStruct(*logReq); err != nil {
-		return common.ErrorWithValidationErrors(fiber.StatusUnprocessableEntity, "can't update Log", "invalid format", err)
+		return common.ErrorWithValidationErrors(fiber.StatusUnprocessableEntity, "can't update Log", err)
 	}
 
 	log := models.Log{}
@@ -218,7 +218,7 @@ func (p *Log) PostSoftwareLog(ctx *fiber.Ctx) error {
 	}
 
 	if err := common.ValidateStruct(*logReq); err != nil {
-		return common.ErrorWithValidationErrors(fiber.StatusUnprocessableEntity, "can't create Log", "invalid format", err)
+		return common.ErrorWithValidationErrors(fiber.StatusUnprocessableEntity, "can't create Log", err)
 	}
 
 	table := models.Software{}.TableName()

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -157,7 +157,7 @@ func (p *Software) PostSoftware(ctx *fiber.Ctx) error {
 
 	if err := common.ValidateStruct(*softwareReq); err != nil {
 		return common.ErrorWithValidationErrors(
-			fiber.StatusUnprocessableEntity, "can't create Software", "invalid format", err,
+			fiber.StatusUnprocessableEntity, "can't create Software", err,
 		)
 	}
 
@@ -208,7 +208,7 @@ func (p *Software) PatchSoftware(ctx *fiber.Ctx) error { //nolint:cyclop // most
 
 	if err := common.ValidateStruct(*softwareReq); err != nil {
 		return common.ErrorWithValidationErrors(
-			fiber.StatusUnprocessableEntity, "can't update Software", "invalid format", err,
+			fiber.StatusUnprocessableEntity, "can't update Software", err,
 		)
 	}
 

--- a/internal/handlers/webhooks.go
+++ b/internal/handlers/webhooks.go
@@ -124,7 +124,7 @@ func (p *Webhook[T]) PostResourceWebhook(ctx *fiber.Ctx) error {
 
 	if err := common.ValidateStruct(*webhookReq); err != nil {
 		return common.ErrorWithValidationErrors(
-			fiber.StatusUnprocessableEntity, "can't create Webhook", "invalid format", err,
+			fiber.StatusUnprocessableEntity, "can't create Webhook", err,
 		)
 	}
 
@@ -168,7 +168,7 @@ func (p *Webhook[T]) PostSingleResourceWebhook(ctx *fiber.Ctx) error {
 
 	if err := common.ValidateStruct(*webhookReq); err != nil {
 		return common.ErrorWithValidationErrors(
-			fiber.StatusUnprocessableEntity, "can't create Webhook", "invalid format", err,
+			fiber.StatusUnprocessableEntity, "can't create Webhook", err,
 		)
 	}
 
@@ -197,7 +197,7 @@ func (p *Webhook[T]) PatchWebhook(ctx *fiber.Ctx) error {
 
 	if err := common.ValidateStruct(*webhookReq); err != nil {
 		return common.ErrorWithValidationErrors(
-			fiber.StatusUnprocessableEntity, "can't update Webhook", "invalid format", err,
+			fiber.StatusUnprocessableEntity, "can't update Webhook", err,
 		)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -520,7 +520,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"alternativeId","rule":"min"}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: alternativeId does not meet its size limits (too short)","status":422,"validationErrors":[{"field":"alternativeId","rule":"min","value":""}]}`,
 		},
 		{
 			query: "POST /v1/publishers - NOT normalized URL validation passed",
@@ -616,7 +616,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"email","rule":"email"}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: email is not a valid email","status":422,"validationErrors":[{"field":"email","rule":"email","value":""}]}`,
 		},
 		{
 			query:    "POST /v1/publishers - Description already exist",
@@ -639,7 +639,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"description","rule":"required"}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST new publisher with empty description",
@@ -651,7 +651,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"description","rule":"required"}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST publisher with duplicate alternativeId",
@@ -675,7 +675,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"codeHosting","rule":"required"},{"field":"description","rule":"required"}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: codeHosting is required, description is required","status":422,"validationErrors":[{"field":"codeHosting","rule":"required","value":""},{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST publishers - wrong token",
@@ -750,7 +750,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Publisher`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: url is invalid, description is required, email is not a valid email", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -871,7 +871,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody: `{"title":"can't update Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"codeHosting","rule":"gt"}]}`,
+			expectedBody: `{"title":"can't update Publisher","detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"validationErrors":[{"field":"codeHosting","rule":"gt","value":""}]}`,
 		},
 		{
 			description: "PATCH a publisher via alternativeId",
@@ -969,7 +969,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody: `{"title":"can't update Publisher","detail":"invalid format","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
+			expectedBody: `{"title":"can't update Publisher","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
 		},
 		{
 			description: "PATCH publishers with empty body",
@@ -1214,7 +1214,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Webhook`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: url is invalid", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -1706,7 +1706,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Software","detail":"invalid format","status":422,"validationErrors":[{"field":"url","rule":"required"}]}`,
+			expectedBody:        `{"title":"can't create Software","detail":"invalid format: url is required","status":422,"validationErrors":[{"field":"url","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST software - wrong token",
@@ -1776,7 +1776,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Software`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: url is required", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -1990,7 +1990,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't update Software`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: url is invalid", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -2244,7 +2244,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Log`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: message is required", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -2457,7 +2457,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Webhook`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: url is invalid", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -2737,7 +2737,7 @@ func TestLogsEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Log","detail":"invalid format","status":422,"validationErrors":[{"field":"message","rule":"required"}]}`,
+			expectedBody:        `{"title":"can't create Log","detail":"invalid format: message is required","status":422,"validationErrors":[{"field":"message","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST log - wrong token",
@@ -2793,7 +2793,7 @@ func TestLogsEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't create Log`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: message is required", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 
@@ -2931,7 +2931,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, `can't update Webhook`, response["title"])
-				assert.Equal(t, "invalid format", response["detail"])
+				assert.Equal(t, "invalid format: url is invalid", response["detail"])
 
 				assert.IsType(t, []interface{}{}, response["validationErrors"])
 


### PR DESCRIPTION
Closes issue #166.

This PR adds a "Detail" field to errors generated by the `ErrorWithValidationErrors`. It does so using a new method called `GenerateErrorDetails` which is found in [validator.go](https://github.com/Bavuett/developers-italia-api/blob/778c232b11639be89708c73ca61a469c48a3b5d9/internal/common/validator.go#L76-L98).

Here is an example of how it works: 

**Request.**

![Schermata del 2023-03-07 20-29-01](https://user-images.githubusercontent.com/43916566/223536478-562f92b6-ee5c-4e2a-94b5-4382c75fcfd0.png)

**Response.**

![Schermata del 2023-03-07 20-28-50](https://user-images.githubusercontent.com/43916566/223536565-6a983f63-5627-403b-bca0-241c23765e1a.png)

Let me know if changes are needed.
