### PR TITLE
chore(ci): bump setup-go action to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
       - uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/publish-staging-docker-image.yml
+++ b/.github/workflows/publish-staging-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
       -

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -10,7 +10,7 @@ jobs:
   release_chart:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get version
         id: get_version
         run: echo "::set-output name=version::${GITHUB_REF_NAME#helm/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
       -

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.18.x
       - run: go test -race ./...


### PR DESCRIPTION
v4 enables caching by default, and should result in lower build times.