### PR TITLE
fix(backward comp): use postgres as default db

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The application will automatically reload when a change is made.
 
 You can configure the API with environment variables:
 
-* `DATABASE_DSN`: the data source used to connect to the database,
-  fe `host=db user=postgres password=postgres dbname=postgres port=5432`.
+* `DATABASE_DSN`: the URI used to connect to the database,
+  fe `postgres://user:password@host:5432/dbname`.
   Supports PostgreSQL and SQLite.
 
 * `PASETO_KEY` (optional): Base64 encoded 32 bytes key used to check the

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -24,7 +24,7 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 		log.Println("using SQLite database")
 
 		database, err = gorm.Open(sqlite.Open(connection), &gorm.Config{TranslateError: true})
-	case strings.HasPrefix(connection, "postgres:"):
+	default:
 		log.Println("using Postgres database")
 
 		database, err = gorm.Open(postgres.Open(connection), &gorm.Config{


### PR DESCRIPTION
Use PostgreSQL as default database, so it works with DSN as well. (fe. host=db user=postgres password=postgres dbname=postgres port=5432)