### PR TITLE
Implement from and get in get publishers

### DIFF
--- a/developers-italia.oas.yaml
+++ b/developers-italia.oas.yaml
@@ -729,6 +729,20 @@ paths:
           in: query
           name: 'page[after]'
           description: Only results after this cursor
+        - schema:
+            type: string
+            format: date-time
+            example: '2022-06-07T09:56:23Z'
+          in: query
+          name: from
+          description: Only publishers created after this time (RFC 3339 datetime)
+        - schema:
+            type: string
+            format: date-time
+            example: '2022-06-07T14:56:23Z'
+          in: query
+          name: to
+          description: Only publishers created before this time (RFC 3339 datetime)
     post:
       summary: Create a new Publisher
       description: Create a new Publisher

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -43,6 +43,15 @@ func (p *Publisher) GetPublishers(ctx *fiber.Ctx) error {
 
 	stmt := p.db.Preload("CodeHosting")
 
+	stmt, err := general.Clauses(ctx, stmt, "")
+	if err != nil {
+		return common.Error(
+			fiber.StatusUnprocessableEntity,
+			"can't get Publishers",
+			err.Error(),
+		)
+	}
+
 	if all := ctx.QueryBool("all", false); !all {
 		stmt = stmt.Scopes(models.Active)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -385,7 +385,7 @@ func TestPublishersEndpoints(t *testing.T) {
 		},
 		{
 			description: `GET with "from" query param`,
-			query:       "GET /v1/publishers?from=2018-11-26T00:56:23Z",
+			query:       "GET /v1/publishers?from=2018-11-10T00:56:23Z",
 
 			expectedCode:        200,
 			expectedContentType: "application/json",

--- a/main_test.go
+++ b/main_test.go
@@ -393,7 +393,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				assert.IsType(t, []interface{}{}, response["data"])
 				data := response["data"].([]interface{})
 
-				assert.Equal(t, 13, len(data))
+				assert.Equal(t, 14, len(data))
 			},
 		},
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -383,6 +383,53 @@ func TestPublishersEndpoints(t *testing.T) {
 				assert.Equal(t, "wrong cursor format in page[after] or page[before]", response["detail"])
 			},
 		},
+		{
+			description: `GET with "from" query param`,
+			query:       "GET /v1/publishers?from=2018-11-26T00:56:23Z",
+
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.IsType(t, []interface{}{}, response["data"])
+				data := response["data"].([]interface{})
+
+				assert.Equal(t, 13, len(data))
+			},
+		},
+		{
+			description: `GET with invalid "from" query param`,
+			query:       "GET /v1/publishers?from=3",
+
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, `can't get Publishers`, response["title"])
+				assert.Equal(t, "invalid date time format (RFC 3339 needed)", response["detail"])
+			},
+		},
+		{
+			description: `GET with "to" query param`,
+			query:       "GET /v1/publishers?to=2018-11-01T09:56:23Z",
+
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := response["data"].([]interface{})
+
+				assert.Equal(t, 13, len(data))
+			},
+		},
+		{
+			description: `GET with invalid "to" query param`,
+			query:       "GET /v1/publishers?to=3",
+
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, `can't get Publishers`, response["title"])
+				assert.Equal(t, "invalid date time format (RFC 3339 needed)", response["detail"])
+			},
+		},
 
 		// GET /publishers/:id
 		{


### PR DESCRIPTION
Implementation of `from` and `to` query parameters in `GET /publishers` as asked in #214 