### PR TITLE
gofiber upgrade to v2.51.0 and application/problem+json update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/go-testfixtures/testfixtures/v3 v3.8.0
 	github.com/gofiber/contrib/paseto v0.0.0-20220621082844-83549332c36e
-	github.com/gofiber/fiber/v2 v2.50.0
+	github.com/gofiber/fiber/v2 v2.51.0
 	github.com/stretchr/testify v1.8.1
 	gorm.io/driver/postgres v1.5.2
 	gorm.io/driver/sqlite v1.5.2
@@ -28,7 +28,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
@@ -47,7 +47,7 @@ require (
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/aead/chacha20poly1305 v0.0.0-20201124145622-1a5aba2a8b29 // indirect
 	github.com/aead/poly1305 v0.0.0-20180717145839-3fee0db0b635 // indirect
-	github.com/google/uuid v1.3.1 // indirect
+	github.com/google/uuid v1.4.0 // indirect
 	github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7 // indirect
 	github.com/o1egl/paseto v1.0.0
 	github.com/pilagod/gorm-cursor-paginator/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/gofiber/contrib/paseto v0.0.0-20220621082844-83549332c36e h1:ZsZeaEFE
 github.com/gofiber/contrib/paseto v0.0.0-20220621082844-83549332c36e/go.mod h1:zU7RONlVB7dBKM0EijoExlxAWJtevT5+9RqAH2imOUI=
 github.com/gofiber/fiber/v2 v2.34.1/go.mod h1:ozRQfS+D7EL1+hMH+gutku0kfx1wLX4hAxDCtDzpj4U=
 github.com/gofiber/fiber/v2 v2.36.0/go.mod h1:tgCr+lierLwLoVHHO/jn3Niannv34WRkQETU8wiL9fQ=
-github.com/gofiber/fiber/v2 v2.50.0 h1:ia0JaB+uw3GpNSCR5nvC5dsaxXjRU5OEu36aytx+zGw=
-github.com/gofiber/fiber/v2 v2.50.0/go.mod h1:21eytvay9Is7S6z+OgPi7c7n4++tnClWmhpimVHMimw=
+github.com/gofiber/fiber/v2 v2.51.0 h1:JNACcZy5e2tGApWB2QrRpenTWn0fq0hkFm6k0C86gKQ=
+github.com/gofiber/fiber/v2 v2.51.0/go.mod h1:xaQRZQJGqnKOQnbQw+ltvku3/h8QxvNi8o6JiJ7Ll0U=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
@@ -167,8 +167,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -282,8 +282,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -53,9 +53,20 @@ func CustomErrorHandler(ctx *fiber.Ctx, err error) error {
 
 	ctx.Status(problemJSON.Status)
 
-	return ctx.JSON(fiber.Map{
-		"title":  problemJSON.Title,
-		"detail": problemJSON.Detail,
-		"status": problemJSON.Status,
-	}, "application/problem+json")
+	if problemJSON.ValidationErrors != nil {
+		err = ctx.JSON(fiber.Map{
+			"title":            problemJSON.Title,
+			"detail":           problemJSON.Detail,
+			"status":           problemJSON.Status,
+			"validationErrors": problemJSON.ValidationErrors,
+		}, "application/problem+json")
+	} else {
+		err = ctx.JSON(fiber.Map{
+			"title":  problemJSON.Title,
+			"detail": problemJSON.Detail,
+			"status": problemJSON.Status,
+		}, "application/problem+json")
+	}
+
+	return err
 }

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -53,20 +53,5 @@ func CustomErrorHandler(ctx *fiber.Ctx, err error) error {
 
 	ctx.Status(problemJSON.Status)
 
-	if problemJSON.ValidationErrors != nil {
-		err = ctx.JSON(fiber.Map{
-			"title":            problemJSON.Title,
-			"detail":           problemJSON.Detail,
-			"status":           problemJSON.Status,
-			"validationErrors": problemJSON.ValidationErrors,
-		}, "application/problem+json")
-	} else {
-		err = ctx.JSON(fiber.Map{
-			"title":  problemJSON.Title,
-			"detail": problemJSON.Detail,
-			"status": problemJSON.Status,
-		}, "application/problem+json")
-	}
-
-	return err
+    return ctx.JSON(problemJSON, "application/problem+json")
 }

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -53,5 +53,5 @@ func CustomErrorHandler(ctx *fiber.Ctx, err error) error {
 
 	ctx.Status(problemJSON.Status)
 
-    return ctx.JSON(problemJSON, "application/problem+json")
+	return ctx.JSON(problemJSON, "application/problem+json")
 }

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -51,11 +51,11 @@ func CustomErrorHandler(ctx *fiber.Ctx, err error) error {
 		}
 	}
 
-	err = ctx.Status(problemJSON.Status).JSON(problemJSON)
+	ctx.Status(problemJSON.Status)
 
-	// Needs to be after the call to JSON(), to override the
-	// automatic Content-Type
-	ctx.Set(fiber.HeaderContentType, "application/problem+json")
-
-	return err
+	return ctx.JSON(fiber.Map{
+		"title":  problemJSON.Title,
+		"detail": problemJSON.Detail,
+		"status": problemJSON.Status,
+	}, "application/problem+json")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -165,7 +165,7 @@ func TestApi(t *testing.T) {
 			query:       "GET /v1/i-dont-exist",
 
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Cannot GET /v1/i-dont-exist","status":404,"title":"Not Found"}`,
+			expectedBody:        `{"title":"Not Found","detail":"Cannot GET /v1/i-dont-exist","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 	}
@@ -436,7 +436,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			description:         "Non-existent publisher",
 			query:               "GET /v1/publishers/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Publisher was not found","status":404,"title":"can't get Publisher"}`,
+			expectedBody:        `{"title":"can't get Publisher","detail":"Publisher was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -560,7 +560,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST publisher with alternativeId matching an existing id",
@@ -572,7 +572,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"Publisher with id '2ded32eb-c45e-4167-9166-a44e18b8adde' already exists","status":409,"title":"can't create Publisher"}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"Publisher with id '2ded32eb-c45e-4167-9166-a44e18b8adde' already exists","status":409}`,
 		},
 		{
 			description: "POST publisher with empty alternativeId",
@@ -584,7 +584,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: alternativeId does not meet its size limits (too short)","status":422,"title":"can't create Publisher","validationErrors":[{"field":"alternativeId","rule":"min","value":""}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: alternativeId does not meet its size limits (too short)","status":422,"validationErrors":[{"field":"alternativeId","rule":"min","value":""}]}`,
 		},
 		{
 			query: "POST /v1/publishers - NOT normalized URL validation passed",
@@ -623,7 +623,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST new publisher with an existing email",
@@ -680,7 +680,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: email is not a valid email","status":422,"title":"can't create Publisher","validationErrors":[{"field":"email","rule":"email","value":""}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: email is not a valid email","status":422,"validationErrors":[{"field":"email","rule":"email","value":""}]}`,
 		},
 		{
 			query: "POST /v1/publishers - Description already exist",
@@ -691,7 +691,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST new publisher with no description",
@@ -703,7 +703,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: description is required","status":422,"title":"can't create Publisher","validationErrors":[{"field":"description","rule":"required","value":""}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST new publisher with empty description",
@@ -715,7 +715,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: description is required","status":422,"title":"can't create Publisher","validationErrors":[{"field":"description","rule":"required","value":""}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST publisher with duplicate alternativeId",
@@ -727,7 +727,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
 		},
 		{
 			description: "POST publishers with invalid payload",
@@ -739,7 +739,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: codeHosting is required","status":422,"title":"can't create Publisher","validationErrors":[{"field":"codeHosting","rule":"required","value":""}]}`,
+			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: codeHosting is required","status":422,"validationErrors":[{"field":"codeHosting","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST publishers - wrong token",
@@ -750,7 +750,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -854,7 +854,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Publisher was not found","status":404,"title":"can't update Publisher"}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"Publisher was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -935,7 +935,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"title":"can't update Publisher","validationErrors":[{"field":"codeHosting","rule":"gt","value":""}]}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"validationErrors":[{"field":"codeHosting","rule":"gt","value":""}]}`,
 		},
 		{
 			description: "PATCH a publisher via alternativeId",
@@ -978,7 +978,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"Publisher with id '47807e0c-0613-4aea-9917-5455cc6eddad' already exists","status":409,"title":"can't update Publisher"}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"Publisher with id '47807e0c-0613-4aea-9917-5455cc6eddad' already exists","status":409}`,
 		},
 		{
 			description: "PATCH publishers - wrong token",
@@ -989,7 +989,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1017,7 +1017,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't update Publisher"}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "PATCH publisher with validation errors",
@@ -1029,7 +1029,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"title":"can't update Publisher","validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
 		},
 		{
 			description: "PATCH publishers with empty body",
@@ -1041,7 +1041,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        400,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid or malformed JSON","status":400,"title":"can't update Publisher"}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"invalid or malformed JSON","status":400}`,
 		},
 		// TODO: enforce this?
 		// {
@@ -1062,7 +1062,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Publisher was not found","status":404,"title":"can't delete Publisher"}`,
+			expectedBody:        `{"title":"can't delete Publisher","detail":"Publisher was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1073,7 +1073,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1229,7 +1229,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1257,7 +1257,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Webhook"}`,
+			expectedBody:        `{"title":"can't create Webhook","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "POST webhook with validation errors",
@@ -1645,7 +1645,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			description:         "Non-existent software",
 			query:               "GET /v1/software/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Software was not found","status":404,"title":"can't get Software"}`,
+			expectedBody:        `{"title":"can't get Software","detail":"Software was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1763,7 +1763,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: url is required","status":422,"title":"can't create Software","validationErrors":[{"field":"url","rule":"required","value":""}]}`,
+			expectedBody:        `{"title":"can't create Software","detail":"invalid format: url is required","status":422,"validationErrors":[{"field":"url","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST software - wrong token",
@@ -1774,7 +1774,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1801,7 +1801,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Software"}`,
+			expectedBody:        `{"title":"can't create Software","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "POST software with optional boolean field set to false",
@@ -1878,7 +1878,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Software was not found","status":404,"title":"can't update Software"}`,
+			expectedBody:        `{"title":"can't update Software","detail":"Software was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2003,7 +2003,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"URL already exists","status":409,"title":"can't update Software"}`,
+			expectedBody:        `{"title":"can't update Software","detail":"URL already exists","status":409}`,
 		},
 		{
 			description: "PATCH software, change active",
@@ -2089,7 +2089,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"URL already exists","status":409,"title":"can't update Software"}`,
+			expectedBody:        `{"title":"can't update Software","detail":"URL already exists","status":409}`,
 		},
 		{
 			description: "PATCH software using an already taken URL as an alias",
@@ -2102,7 +2102,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"URL already exists","status":409,"title":"can't update Software"}`,
+			expectedBody:        `{"title":"can't update Software","detail":"URL already exists","status":409}`,
 		},
 		{
 			description: "PATCH software - wrong token",
@@ -2113,7 +2113,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2141,7 +2141,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't update Software"}`,
+			expectedBody:        `{"title":"can't update Software","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "PATCH software with validation errors",
@@ -2180,7 +2180,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"title":"can't update Software","validationErrors":[{"field":"url","rule":"url","value":""}]}`,
+			expectedBody:        `{"title":"can't update Software","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":""}]}`,
 		},
 		{
 			description: "PATCH software with empty body",
@@ -2216,7 +2216,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Software was not found","status":404,"title":"can't delete Software"}`,
+			expectedBody:        `{"title":"can't delete Software","detail":"Software was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2227,7 +2227,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2377,7 +2377,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2405,7 +2405,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Log"}`,
+			expectedBody:        `{"title":"can't create Log","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "POST log with validation errors",
@@ -2587,7 +2587,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2615,7 +2615,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Webhook"}`,
+			expectedBody:        `{"title":"can't create Webhook","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "POST webhook with validation errors",
@@ -2867,7 +2867,7 @@ func TestLogsEndpoints(t *testing.T) {
 			description:         "Non-existent log",
 			query:               "GET /v1/logs/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode:        404,
-			expectedBody:        `{"detail":"Log was not found","status":404,"title":"can't get Log"}`,
+			expectedBody:        `{"title":"can't get Log","detail":"Log was not found","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		// POST /logs
@@ -2909,7 +2909,7 @@ func TestLogsEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Log"}`,
+			expectedBody:        `{"title":"can't create Log","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "POST log - wrong token",
@@ -2920,7 +2920,7 @@ func TestLogsEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2948,7 +2948,7 @@ func TestLogsEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Log"}`,
+			expectedBody:        `{"title":"can't create Log","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "POST log with validation errors",
@@ -3018,7 +3018,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 			description:  "Non-existent webhook",
 			query:        "GET /v1/webhooks/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode: 404,
-			expectedBody: `{"detail":"Webhook was not found","status":404,"title":"can't get Webhook"}`,
+			expectedBody: `{"title":"can't get Webhook","detail":"Webhook was not found","status":404}`,
 
 			expectedContentType: "application/problem+json",
 		},
@@ -3055,7 +3055,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -3083,7 +3083,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't update Webhook"}`,
+			expectedBody:        `{"title":"can't update Webhook","detail":"unknown field in JSON input","status":422}`,
 		},
 		{
 			description: "PATCH webhook with validation errors",
@@ -3148,7 +3148,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 			// This error is different from because it's returned directly from Fiber's
 			// route constraints, so we don't need to hit the database to find the resource
 			// because we already know that's not a valid webhook id looking at its format.
-			expectedBody:        `{"detail":"Cannot DELETE /v1/webhooks/NO_SUCH_WEBHOOK","status":404,"title":"Not Found"}`,
+			expectedBody:        `{"title":"Not Found","detail":"Cannot DELETE /v1/webhooks/NO_SUCH_WEBHOOK","status":404}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -3159,7 +3159,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
 			expectedContentType: "application/problem+json",
 		},
 		{

--- a/main_test.go
+++ b/main_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 
-	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 const UUID_REGEXP = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
@@ -35,9 +35,9 @@ type TestCase struct {
 	description string
 
 	// Test input
-	query    string
-	body     string
-	headers  map[string][]string
+	query   string
+	body    string
+	headers map[string][]string
 
 	// Expected output
 	expectedCode        int
@@ -165,7 +165,7 @@ func TestApi(t *testing.T) {
 			query:       "GET /v1/i-dont-exist",
 
 			expectedCode:        404,
-			expectedBody:        `{"title":"Not Found","detail":"Cannot GET /v1/i-dont-exist","status":404}`,
+			expectedBody:        `{"detail":"Cannot GET /v1/i-dont-exist","status":404,"title":"Not Found"}`,
 			expectedContentType: "application/problem+json",
 		},
 	}
@@ -436,7 +436,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			description:         "Non-existent publisher",
 			query:               "GET /v1/publishers/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't get Publisher","detail":"Publisher was not found","status":404}`,
+			expectedBody:        `{"detail":"Publisher was not found","status":404,"title":"can't get Publisher"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -552,39 +552,39 @@ func TestPublishersEndpoints(t *testing.T) {
 		},
 		{
 			description: "POST publisher with duplicate alternativeId",
-			query: "POST /v1/publishers",
-			body:  `{"alternativeId": "alternative-id-12345", "description":"new description", "codeHosting": [{"url" : "https://example-testcase-xx3.com"}], "email":"example-testcase-3-pass@example.com"}`,
+			query:       "POST /v1/publishers",
+			body:        `{"alternativeId": "alternative-id-12345", "description":"new description", "codeHosting": [{"url" : "https://example-testcase-xx3.com"}], "email":"example-testcase-3-pass@example.com"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
+			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST publisher with alternativeId matching an existing id",
-			query: "POST /v1/publishers",
-			body:  `{"alternativeId": "2ded32eb-c45e-4167-9166-a44e18b8adde", "description":"new description", "codeHosting": [{"url" : "https://example-testcase-xx3.com"}]}`,
+			query:       "POST /v1/publishers",
+			body:        `{"alternativeId": "2ded32eb-c45e-4167-9166-a44e18b8adde", "description":"new description", "codeHosting": [{"url" : "https://example-testcase-xx3.com"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"Publisher with id '2ded32eb-c45e-4167-9166-a44e18b8adde' already exists","status":409}`,
+			expectedBody:        `{"detail":"Publisher with id '2ded32eb-c45e-4167-9166-a44e18b8adde' already exists","status":409,"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST publisher with empty alternativeId",
-			query: "POST /v1/publishers",
-			body:  `{"alternativeId": "", "description":"new description", "codeHosting": [{"url" : "https://gitlab.example.com/repo"}]}`,
+			query:       "POST /v1/publishers",
+			body:        `{"alternativeId": "", "description":"new description", "codeHosting": [{"url" : "https://gitlab.example.com/repo"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: alternativeId does not meet its size limits (too short)","status":422,"validationErrors":[{"field":"alternativeId","rule":"min","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: alternativeId does not meet its size limits (too short)","status":422,"title":"can't create Publisher","validationErrors":[{"field":"alternativeId","rule":"min","value":""}]}`,
 		},
 		{
 			query: "POST /v1/publishers - NOT normalized URL validation passed",
@@ -616,14 +616,14 @@ func TestPublishersEndpoints(t *testing.T) {
 		{
 			description: "POST publishers with duplicate URL (when normalized)",
 			query:       "POST /v1/publishers",
-			body: `{"codeHosting": [{"url" : "https://1-a.exAMple.org/code/repo"}], "description":"new description"}`,
+			body:        `{"codeHosting": [{"url" : "https://1-a.exAMple.org/code/repo"}], "description":"new description"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
+			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST new publisher with an existing email",
@@ -640,9 +640,9 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 		},
 		{
-			description:    "POST new publisher with an existing email (not normalized)",
-			query:          "POST /v1/publishers",
-			body:     `{"codeHosting": [{"url" : "https://new-url.example.com"}], "email":"FoobaR@1.example.org", "description": "new publisher description"}`,
+			description: "POST new publisher with an existing email (not normalized)",
+			query:       "POST /v1/publishers",
+			body:        `{"codeHosting": [{"url" : "https://new-url.example.com"}], "email":"FoobaR@1.example.org", "description": "new publisher description"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -654,9 +654,9 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 		},
 		{
-			description:    "POST new publisher with no email",
-			query:          "POST /v1/publishers",
-			body: `{"codeHosting": [{"url" : "https://new-url.example.com"}], "description": "new publisher description"}`,
+			description: "POST new publisher with no email",
+			query:       "POST /v1/publishers",
+			body:        `{"codeHosting": [{"url" : "https://new-url.example.com"}], "description": "new publisher description"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -671,27 +671,27 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 		},
 		{
-			description:    "POST new publisher with empty email",
-			query:          "POST /v1/publishers",
-			body: `{"email": "", "codeHosting": [{"url" : "https://new-url.example.com"}], "description": "new publisher description"}`,
+			description: "POST new publisher with empty email",
+			query:       "POST /v1/publishers",
+			body:        `{"email": "", "codeHosting": [{"url" : "https://new-url.example.com"}], "description": "new publisher description"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: email is not a valid email","status":422,"validationErrors":[{"field":"email","rule":"email","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: email is not a valid email","status":422,"title":"can't create Publisher","validationErrors":[{"field":"email","rule":"email","value":""}]}`,
 		},
 		{
-			query:    "POST /v1/publishers - Description already exist",
-			body:     `{"codeHosting": [{"url" : "https://example-testcase-xx3.com"}], "description": "Publisher description 1"}`,
+			query: "POST /v1/publishers - Description already exist",
+			body:  `{"codeHosting": [{"url" : "https://example-testcase-xx3.com"}], "description": "Publisher description 1"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
+			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST new publisher with no description",
@@ -703,7 +703,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}],"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST new publisher with empty description",
@@ -715,19 +715,19 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}],"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST publisher with duplicate alternativeId",
-			query: "POST /v1/publishers",
-			body:  `{"alternativeId": "alternative-id-12345", "description":"new description", "codeHosting": [{"url" : "https://example-testcase-xx3.com"}]}`,
+			query:       "POST /v1/publishers",
+			body:        `{"alternativeId": "alternative-id-12345", "description":"new description", "codeHosting": [{"url" : "https://example-testcase-xx3.com"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"description, alternativeId or codeHosting URL already exists","status":409}`,
+			expectedBody:        `{"detail":"description, alternativeId or codeHosting URL already exists","status":409,"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST publishers with invalid payload",
@@ -739,7 +739,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Publisher","detail":"invalid format: codeHosting is required","status":422,"validationErrors":[{"field":"codeHosting","rule":"required","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: codeHosting is required","status":422,"validationErrors":[{"field":"codeHosting","rule":"required","value":""}],"title":"can't create Publisher"}`,
 		},
 		{
 			description: "POST publishers - wrong token",
@@ -750,7 +750,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -854,13 +854,13 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't update Publisher","detail":"Publisher was not found","status":404}`,
+			expectedBody:        `{"detail":"Publisher was not found","status":404,"title":"can't update Publisher"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
 			description: "PATCH a publisher",
-			query: "PATCH /v1/publishers/2ded32eb-c45e-4167-9166-a44e18b8adde",
-			body:  `{"description": "new PATCHed description", "codeHosting": [{"url": "https://gitlab.example.org/patched-repo"}]}`,
+			query:       "PATCH /v1/publishers/2ded32eb-c45e-4167-9166-a44e18b8adde",
+			body:        `{"description": "new PATCHed description", "codeHosting": [{"url": "https://gitlab.example.org/patched-repo"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -935,12 +935,12 @@ func TestPublishersEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody: `{"title":"can't update Publisher","detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"validationErrors":[{"field":"codeHosting","rule":"gt","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"validationErrors":[{"field":"codeHosting","rule":"gt","value":""}],"title":"can't update Publisher"}`,
 		},
 		{
 			description: "PATCH a publisher via alternativeId",
-			query: "PATCH /v1/publishers/alternative-id-12345",
-			body:  `{"description": "new PATCHed description via alternativeId", "codeHosting": [{"url": "https://gitlab.example.org/patched-repo"}]}`,
+			query:       "PATCH /v1/publishers/alternative-id-12345",
+			body:        `{"description": "new PATCHed description via alternativeId", "codeHosting": [{"url": "https://gitlab.example.org/patched-repo"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -970,15 +970,15 @@ func TestPublishersEndpoints(t *testing.T) {
 		},
 		{
 			description: "PATCH a publisher with alternativeId matching an existing id",
-			query: "PATCH /v1/publishers/2ded32eb-c45e-4167-9166-a44e18b8adde",
-			body:  `{"alternativeId": "47807e0c-0613-4aea-9917-5455cc6eddad"}`,
+			query:       "PATCH /v1/publishers/2ded32eb-c45e-4167-9166-a44e18b8adde",
+			body:        `{"alternativeId": "47807e0c-0613-4aea-9917-5455cc6eddad"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Publisher","detail":"Publisher with id '47807e0c-0613-4aea-9917-5455cc6eddad' already exists","status":409}`,
+			expectedBody:        `{"detail":"Publisher with id '47807e0c-0613-4aea-9917-5455cc6eddad' already exists","status":409,"title":"can't update Publisher"}`,
 		},
 		{
 			description: "PATCH publishers - wrong token",
@@ -989,7 +989,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1010,14 +1010,14 @@ func TestPublishersEndpoints(t *testing.T) {
 		{
 			description: "PATCH publishers with JSON with extra fields",
 			query:       "PATCH /v1/publishers/2ded32eb-c45e-4167-9166-a44e18b8adde",
-			body: `{"description": "new description", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"description": "new description", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody: `{"title":"can't update Publisher","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't update Publisher"}`,
 		},
 		{
 			description: "PATCH publisher with validation errors",
@@ -1029,7 +1029,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody: `{"title":"can't update Publisher","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
+			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}],"title":"can't update Publisher"}`,
 		},
 		{
 			description: "PATCH publishers with empty body",
@@ -1041,7 +1041,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        400,
 			expectedContentType: "application/problem+json",
-			expectedBody: `{"title":"can't update Publisher","detail":"invalid or malformed JSON","status":400}`,
+			expectedBody:        `{"detail":"invalid or malformed JSON","status":400,"title":"can't update Publisher"}`,
 		},
 		// TODO: enforce this?
 		// {
@@ -1062,7 +1062,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't delete Publisher","detail":"Publisher was not found","status":404}`,
+			expectedBody:        `{"detail":"Publisher was not found","status":404,"title":"can't delete Publisher"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1073,11 +1073,11 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
-			query:    "DELETE /v1/publishers/15fda7c4-6bbf-4387-8f89-258c1e6fafb1",
+			query: "DELETE /v1/publishers/15fda7c4-6bbf-4387-8f89-258c1e6fafb1",
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -1088,7 +1088,7 @@ func TestPublishersEndpoints(t *testing.T) {
 		},
 		{
 			description: "DELETE publisher via alternativeId",
-			query: "DELETE /v1/publishers/alternative-id-12345",
+			query:       "DELETE /v1/publishers/alternative-id-12345",
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -1102,7 +1102,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 		// GET /publishers/:id/webhooks
 		{
-			query:    "GET /v1/publishers/47807e0c-0613-4aea-9917-5455cc6eddad/webhooks",
+			query: "GET /v1/publishers/47807e0c-0613-4aea-9917-5455cc6eddad/webhooks",
 
 			expectedCode:        200,
 			expectedContentType: "application/json",
@@ -1192,8 +1192,8 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 		},
 		{
-			query:    "POST /v1/publishers/98a069f7-57b0-464d-b300-4b4b336297a0/webhooks",
-			body:     `{"url": "https://new.example.org", "secret": "xyz"}`,
+			query: "POST /v1/publishers/98a069f7-57b0-464d-b300-4b4b336297a0/webhooks",
+			body:  `{"url": "https://new.example.org", "secret": "xyz"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -1229,7 +1229,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1250,14 +1250,14 @@ func TestPublishersEndpoints(t *testing.T) {
 		{
 			description: "POST /v1/publishers/98a069f7-57b0-464d-b300-4b4b336297a0/webhooks with JSON with extra fields",
 			query:       "POST /v1/publishers/98a069f7-57b0-464d-b300-4b4b336297a0/webhooks",
-			body: `{"url": "https://new.example.org", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"url": "https://new.example.org", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Webhook","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Webhook"}`,
 		},
 		{
 			description: "POST webhook with validation errors",
@@ -1645,7 +1645,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			description:         "Non-existent software",
 			query:               "GET /v1/software/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't get Software","detail":"Software was not found","status":404}`,
+			expectedBody:        `{"detail":"Software was not found","status":404,"title":"can't get Software"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1763,7 +1763,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Software","detail":"invalid format: url is required","status":422,"validationErrors":[{"field":"url","rule":"required","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: url is required","status":422,"validationErrors":[{"field":"url","rule":"required","value":""}],"title":"can't create Software"}`,
 		},
 		{
 			description: "POST software - wrong token",
@@ -1774,7 +1774,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -1794,14 +1794,14 @@ func TestSoftwareEndpoints(t *testing.T) {
 		{
 			description: "POST /v1/software with JSON with extra fields",
 			query:       "POST /v1/software",
-			body: `{"publiccodeYml": "-", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"publiccodeYml": "-", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Software","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Software"}`,
 		},
 		{
 			description: "POST software with optional boolean field set to false",
@@ -1878,13 +1878,13 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't update Software","detail":"Software was not found","status":404}`,
+			expectedBody:        `{"detail":"Software was not found","status":404,"title":"can't update Software"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
 			description: "PATCH a software resource",
-			query: "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
-			body:  `{"publiccodeYml": "publiccodedata", "url": "https://software-new.example.org", "aliases": ["https://software.example.com", "https://software-old.example.org"]}`,
+			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
+			body:        `{"publiccodeYml": "publiccodedata", "url": "https://software-new.example.org", "aliases": ["https://software.example.com", "https://software-old.example.org"]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -1930,7 +1930,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        200,
 			expectedContentType: "application/json",
-			expectedBody: "",
+			expectedBody:        "",
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assert.Equal(t, true, response["active"])
 				assert.Equal(t, "https://software-new.example.org", response["url"])
@@ -2003,7 +2003,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Software","detail":"URL already exists","status":409}`,
+			expectedBody:        `{"detail":"URL already exists","status":409,"title":"can't update Software"}`,
 		},
 		{
 			description: "PATCH software, change active",
@@ -2089,7 +2089,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Software","detail":"URL already exists","status":409}`,
+			expectedBody:        `{"detail":"URL already exists","status":409,"title":"can't update Software"}`,
 		},
 		{
 			description: "PATCH software using an already taken URL as an alias",
@@ -2102,7 +2102,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        409,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Software","detail":"URL already exists","status":409}`,
+			expectedBody:        `{"detail":"URL already exists","status":409,"title":"can't update Software"}`,
 		},
 		{
 			description: "PATCH software - wrong token",
@@ -2113,7 +2113,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2141,7 +2141,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Software","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't update Software"}`,
 		},
 		{
 			description: "PATCH software with validation errors",
@@ -2180,7 +2180,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Software","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":""}]}`,
+			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":""}],"title":"can't update Software"}`,
 		},
 		{
 			description: "PATCH software with empty body",
@@ -2209,14 +2209,14 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 		// DELETE /software/:id
 		{
-			description:         "Delete non-existent software",
-			query:               "DELETE /v1/software/eea19c82-0449-11ed-bd84-d8bbc146d165",
+			description: "Delete non-existent software",
+			query:       "DELETE /v1/software/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't delete Software","detail":"Software was not found","status":404}`,
+			expectedBody:        `{"detail":"Software was not found","status":404,"title":"can't delete Software"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2227,11 +2227,11 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
-			query:    "DELETE /v1/software/11e101c4-f989-4cc4-a665-63f9f34e83f6",
+			query: "DELETE /v1/software/11e101c4-f989-4cc4-a665-63f9f34e83f6",
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -2244,7 +2244,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 		// GET /software/:id/logs
 		{
-			query:    "GET /v1/software/c353756e-8597-4e46-a99b-7da2e141603b/logs",
+			query: "GET /v1/software/c353756e-8597-4e46-a99b-7da2e141603b/logs",
 
 			expectedCode:        200,
 			expectedContentType: "application/json",
@@ -2342,8 +2342,8 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 		},
 		{
-			query:    "POST /v1/software/c353756e-8597-4e46-a99b-7da2e141603b/logs",
-			body:     `{"message": "New software log from test suite"}`,
+			query: "POST /v1/software/c353756e-8597-4e46-a99b-7da2e141603b/logs",
+			body:  `{"message": "New software log from test suite"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -2377,7 +2377,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2398,14 +2398,14 @@ func TestSoftwareEndpoints(t *testing.T) {
 		{
 			description: "POST /v1/software/c353756e-8597-4e46-a99b-7da2e141603b/logs with JSON with extra fields",
 			query:       "POST /v1/software/c353756e-8597-4e46-a99b-7da2e141603b/logs",
-			body: `{"message": "new log", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"message": "new log", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Log","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Log"}`,
 		},
 		{
 			description: "POST log with validation errors",
@@ -2460,7 +2460,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 		// GET /software/:id/webhooks
 		{
-			query:    "GET /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
+			query: "GET /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
 
 			expectedCode:        200,
 			expectedContentType: "application/json",
@@ -2550,8 +2550,8 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 		},
 		{
-			query:    "POST /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
-			body:     `{"url": "https://new.example.org", "secret": "xyz"}`,
+			query: "POST /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
+			body:  `{"url": "https://new.example.org", "secret": "xyz"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -2587,7 +2587,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2608,14 +2608,14 @@ func TestSoftwareEndpoints(t *testing.T) {
 		{
 			description: "POST /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks with JSON with extra fields",
 			query:       "POST /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
-			body: `{"url": "https://new.example.org", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"url": "https://new.example.org", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Webhook","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Webhook"}`,
 		},
 		{
 			description: "POST webhook with validation errors",
@@ -2867,7 +2867,7 @@ func TestLogsEndpoints(t *testing.T) {
 			description:         "Non-existent log",
 			query:               "GET /v1/logs/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode:        404,
-			expectedBody:        `{"title":"can't get Log","detail":"Log was not found","status":404}`,
+			expectedBody:        `{"detail":"Log was not found","status":404,"title":"can't get Log"}`,
 			expectedContentType: "application/problem+json",
 		},
 		// POST /logs
@@ -2909,7 +2909,7 @@ func TestLogsEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Log","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Log"}`,
 		},
 		{
 			description: "POST log - wrong token",
@@ -2920,7 +2920,7 @@ func TestLogsEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -2941,14 +2941,14 @@ func TestLogsEndpoints(t *testing.T) {
 		{
 			description: "POST /v1/logs with JSON with extra fields",
 			query:       "POST /v1/logs",
-			body: `{"message": "new log", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"message": "new log", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Log","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't create Log"}`,
 		},
 		{
 			description: "POST log with validation errors",
@@ -3018,15 +3018,15 @@ func TestWebhooksEndpoints(t *testing.T) {
 			description:  "Non-existent webhook",
 			query:        "GET /v1/webhooks/eea19c82-0449-11ed-bd84-d8bbc146d165",
 			expectedCode: 404,
-			expectedBody: `{"title":"can't get Webhook","detail":"Webhook was not found","status":404}`,
+			expectedBody: `{"detail":"Webhook was not found","status":404,"title":"can't get Webhook"}`,
 
 			expectedContentType: "application/problem+json",
 		},
 
 		// PATCH /webhooks/:id
 		{
-			query:    "PATCH /v1/webhooks/007bc84a-7e2d-43a0-b7e1-a256d4114aa7",
-			body:     `{"url": "https://new.example.org/receiver"}`,
+			query: "PATCH /v1/webhooks/007bc84a-7e2d-43a0-b7e1-a256d4114aa7",
+			body:  `{"url": "https://new.example.org/receiver"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -3055,7 +3055,7 @@ func TestWebhooksEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -3076,14 +3076,14 @@ func TestWebhooksEndpoints(t *testing.T) {
 		{
 			description: "PATCH /v1/webhooks/007bc84a-7e2d-43a0-b7e1-a256d4114aa7 with JSON with extra fields",
 			query:       "PATCH /v1/webhooks/007bc84a-7e2d-43a0-b7e1-a256d4114aa7",
-			body: `{"url": "https://new.example.org/receiver", "EXTRA_FIELD": "extra field not in schema"}`,
+			body:        `{"url": "https://new.example.org/receiver", "EXTRA_FIELD": "extra field not in schema"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Webhook","detail":"unknown field in JSON input","status":422}`,
+			expectedBody:        `{"detail":"unknown field in JSON input","status":422,"title":"can't update Webhook"}`,
 		},
 		{
 			description: "PATCH webhook with validation errors",
@@ -3138,17 +3138,17 @@ func TestWebhooksEndpoints(t *testing.T) {
 
 		// DELETE /webhooks/:id
 		{
-			description:         "Delete non-existent webhook",
-			query:               "DELETE /v1/webhooks/NO_SUCH_WEBHOOK",
+			description: "Delete non-existent webhook",
+			query:       "DELETE /v1/webhooks/NO_SUCH_WEBHOOK",
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
 			},
-			expectedCode:        404,
+			expectedCode: 404,
 			// This error is different from because it's returned directly from Fiber's
 			// route constraints, so we don't need to hit the database to find the resource
 			// because we already know that's not a valid webhook id looking at its format.
-			expectedBody:        `{"title":"Not Found","detail":"Cannot DELETE /v1/webhooks/NO_SUCH_WEBHOOK","status":404}`,
+			expectedBody:        `{"detail":"Cannot DELETE /v1/webhooks/NO_SUCH_WEBHOOK","status":404,"title":"Not Found"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
@@ -3159,11 +3159,11 @@ func TestWebhooksEndpoints(t *testing.T) {
 				"Content-Type":  {"application/json"},
 			},
 			expectedCode:        401,
-			expectedBody:        `{"title":"token authentication failed","status":401}`,
+			expectedBody:        `{"detail":"","status":401,"title":"token authentication failed"}`,
 			expectedContentType: "application/problem+json",
 		},
 		{
-			query:    "DELETE /v1/webhooks/24bc1b5d-fe81-47be-9d55-910f820bdd04",
+			query: "DELETE /v1/webhooks/24bc1b5d-fe81-47be-9d55-910f820bdd04",
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},

--- a/main_test.go
+++ b/main_test.go
@@ -703,7 +703,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}],"title":"can't create Publisher"}`,
+			expectedBody:        `{"detail":"invalid format: description is required","status":422,"title":"can't create Publisher","validationErrors":[{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST new publisher with empty description",
@@ -715,7 +715,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: description is required","status":422,"validationErrors":[{"field":"description","rule":"required","value":""}],"title":"can't create Publisher"}`,
+			expectedBody:        `{"detail":"invalid format: description is required","status":422,"title":"can't create Publisher","validationErrors":[{"field":"description","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST publisher with duplicate alternativeId",
@@ -739,7 +739,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: codeHosting is required","status":422,"validationErrors":[{"field":"codeHosting","rule":"required","value":""}],"title":"can't create Publisher"}`,
+			expectedBody:        `{"detail":"invalid format: codeHosting is required","status":422,"title":"can't create Publisher","validationErrors":[{"field":"codeHosting","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST publishers - wrong token",
@@ -935,7 +935,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"validationErrors":[{"field":"codeHosting","rule":"gt","value":""}],"title":"can't update Publisher"}`,
+			expectedBody:        `{"detail":"invalid format: codeHosting does not meet its size limits (too few items)","status":422,"title":"can't update Publisher","validationErrors":[{"field":"codeHosting","rule":"gt","value":""}]}`,
 		},
 		{
 			description: "PATCH a publisher via alternativeId",
@@ -1029,7 +1029,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}],"title":"can't update Publisher"}`,
+			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"title":"can't update Publisher","validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
 		},
 		{
 			description: "PATCH publishers with empty body",
@@ -1763,7 +1763,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: url is required","status":422,"validationErrors":[{"field":"url","rule":"required","value":""}],"title":"can't create Software"}`,
+			expectedBody:        `{"detail":"invalid format: url is required","status":422,"title":"can't create Software","validationErrors":[{"field":"url","rule":"required","value":""}]}`,
 		},
 		{
 			description: "POST software - wrong token",
@@ -2180,7 +2180,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":""}],"title":"can't update Software"}`,
+			expectedBody:        `{"detail":"invalid format: url is invalid","status":422,"title":"can't update Software","validationErrors":[{"field":"url","rule":"url","value":""}]}`,
 		},
 		{
 			description: "PATCH software with empty body",


### PR DESCRIPTION
**Not actually ready to merge yet**, due to failing tests (see below)

I believe this is right, but I wanted to check that this is looking right to y'all.

Response looks good, identical to response before change, except that the order of properties is moved around.

Because of the changed order in the response, _many_ tests will need to be changed.  For example in TestApi:

``expectedBody:        `{"title":"Not Found","detail":"Cannot GET /v1/i-dont-exist","status":404}`,``

will need to become

``expectedBody:        `{"detail":"Cannot GET /v1/i-dont-exist","status":404,"title":"Not Found"}`,``

and so on.  Lots of little manual changes in the expected body values.  I'll also need to add a check for empty details, because some tests are failing due to `details: ""` being included in the response.

I can do those manual changes in the tests, but it'll take some time so I'll need to come back to it later today or tomorrow.

Also, I went ahead and upgraded gofiber to v2.51.  Doesn't seem to introduce any breaking changes, so I assume that's fine?  I didn't check the gofiber upgrade very thoroughly; I would understand if that needs to be a separate PR though.