### PR TITLE
chore: pin the version of golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,5 @@ jobs:
           go-version: 1.18.x
       - uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.55.2
           args: --timeout 3m --verbose


### PR DESCRIPTION
Fix #227.