### PR TITLE
fix: remove codeHostings when deleting publishers

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -35,7 +35,7 @@ type Publisher struct {
 	ID            string        `json:"id" gorm:"primaryKey"`
 	Email         *string       `json:"email,omitempty"`
 	Description   string        `json:"description" gorm:"uniqueIndex;not null"`
-	CodeHosting   []CodeHosting `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:SET NULL;unique"`
+	CodeHosting   []CodeHosting `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;unique"`
 	Active        *bool         `json:"active" gorm:"default:true;not null"`
 	AlternativeID *string       `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
 	CreatedAt     time.Time     `json:"createdAt" gorm:"index"`


### PR DESCRIPTION
Remove the associated codeHostings when using DELETE on a publisher.

Code hostings are mapped 1-to-1 with a publisher, so they they're part of the resource.
Not deleting them means we'd have dangling code hosting with no publisher, invisible to the API, and that can't be associated to a publisher anymore.