### PR TITLE
chore: bump publiccode.yml softwareVersion to v1.0.0

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -2,12 +2,12 @@
 # metadata file that makes public software easily discoverable.
 # More info at https://github.com/publiccodeyml/publiccode.yml
 
-publiccodeYmlVersion: '0.4'
+publiccodeYmlVersion: "0.4"
 categories:
   - data-collection
 description:
   it:
-    apiDocumentation: 'https://developers.italia.it/it/api/developers-italia'
+    apiDocumentation: "https://developers.italia.it/it/api/developers-italia"
     features:
       - RESTful API Design
       - Can use either SQLite or PostgreSQL
@@ -25,14 +25,14 @@ description:
     shortDescription: |-
       RESTful API for the free and open-source software catalog aimed at Italian
       public administrations.
-developmentStatus: beta
+developmentStatus: stable
 it:
   conforme:
     gdpr: false
     lineeGuidaDesign: false
     misureMinimeSicurezza: true
     modelloInteroperabilita: true
-  countryExtensionVersion: '0.2'
+  countryExtensionVersion: "0.2"
   piattaforme:
     anpr: false
     cie: false
@@ -59,5 +59,5 @@ dependsOn:
     - name: PostgreSQL
       optional: true
 softwareType: standalone/backend
-softwareVersion: v0.12.0
-url: 'https://github.com/italia/developers-italia-api'
+softwareVersion: v1.0.0
+url: "https://github.com/italia/developers-italia-api"


### PR DESCRIPTION
The API has been in prod for quite some time now, let's decalare it stable software.