### PR TITLE
refactor: use explicit assignment for stmt.Where() in GetAllSoftware

### DIFF
--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -68,7 +68,7 @@ func (p *Software) GetAllSoftware(ctx *fiber.Ctx) error { //nolint:cyclop // mos
 			)
 		}
 
-		stmt.Where("id = ?", softwareURL.SoftwareID)
+		stmt = stmt.Where("id = ?", softwareURL.SoftwareID)
 	} else {
 		if all := ctx.QueryBool("all", false); !all {
 			stmt = stmt.Scopes(models.Active)


### PR DESCRIPTION
It worked anyway because of a GORM side effect, but explicit assignment is the correct usage.