### PR TITLE
fix: copy paginator config by value to prevent global mutation

### DIFF
--- a/internal/handlers/general/pagination.go
+++ b/internal/handlers/general/pagination.go
@@ -23,7 +23,7 @@ func NewPaginator(ctx *fiber.Ctx) *paginator.Paginator {
 }
 
 func NewPaginatorWithConfig(ctx *fiber.Ctx, config *paginator.Config) *paginator.Paginator {
-	mergedConf := DefaultConfig
+	mergedConf := *DefaultConfig
 
 	if len(config.Keys) != 0 {
 		mergedConf.Keys = config.Keys
@@ -33,11 +33,11 @@ func NewPaginatorWithConfig(ctx *fiber.Ctx, config *paginator.Config) *paginator
 		mergedConf.Limit = config.Limit
 	}
 
-	if config.Order != DefaultConfig.Order {
+	if config.Order != "" {
 		mergedConf.Order = config.Order
 	}
 
-	paginator := paginator.New(mergedConf)
+	paginator := paginator.New(&mergedConf)
 
 	if after := ctx.Query("page[after]"); after != "" {
 		paginator.SetAfterCursor(after)

--- a/internal/handlers/general/pagination_test.go
+++ b/internal/handlers/general/pagination_test.go
@@ -1,0 +1,29 @@
+package general
+
+import (
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/pilagod/gorm-cursor-paginator/v2/paginator"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func newTestCtx() (*fiber.App, *fiber.Ctx) {
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+	return app, ctx
+}
+
+// TestNewPaginatorWithConfig_DoesNotMutateDefaultConfig verifies that calling
+// NewPaginatorWithConfig with a custom Order does not mutate the global
+// DefaultConfig, so subsequent callers still get the default ASC order.
+func TestNewPaginatorWithConfig_DoesNotMutateDefaultConfig(t *testing.T) {
+	app, ctx := newTestCtx()
+	defer app.ReleaseCtx(ctx)
+
+	NewPaginatorWithConfig(ctx, &paginator.Config{Order: paginator.DESC})
+
+	assert.Equal(t, paginator.ASC, DefaultConfig.Order,
+		"DefaultConfig.Order must not be mutated by NewPaginatorWithConfig")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -2802,7 +2802,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				links := response["links"].(map[string]interface{})
 				assert.Nil(t, links["prev"])
-				assert.Equal(t, "?page[after]=WyIyMDE3LTA1LTAxVDAwOjAwOjAwWiIsImU3ZjZkYmRhLWMzZjUtNGIyZi1iM2Q4LTM5YTM0MDI2ZTYwYSJd", links["next"])
+				assert.Equal(t, "?page[after]=WyIyMDE3LTA1LTAxVDAwOjAwOjAwWiIsImQ2MzM0MDAwLTY5YTgtNDNhMS1hYjQzLTUwYmIwNGUxNGVlZCJd", links["next"])
 			},
 		},
 


### PR DESCRIPTION
DefaultConfig is a pointer, so assigning it without dereferencing shared the same struct between calls.

Also fix a wrong expected cursor in the software webhooks pagination test, which was masking the sort order corruption.