### PR TITLE
feat: add healthcheck middleware

### DIFF
--- a/charts/developers-italia-api/templates/deployment.yaml
+++ b/charts/developers-italia-api/templates/deployment.yaml
@@ -60,11 +60,11 @@ spec:
                   key: pasetoKey
           livenessProbe:
             httpGet:
-              path: /v1/status
+              path: /livez
               port: http
           readinessProbe:
             httpGet:
-              path: /v1/status
+              path: /readyz
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/caarlos0/env/v6"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cache"
+	"github.com/gofiber/fiber/v2/middleware/healthcheck"
 	"github.com/gofiber/fiber/v2/middleware/limiter"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/italia/developers-italia-api/internal/common"
@@ -60,6 +61,12 @@ func Setup() *fiber.App {
 
 	// Automatically recover panics in handlers
 	app.Use(recover.New())
+
+	app.Use(healthcheck.New(healthcheck.Config{
+		ReadinessProbe: func(c *fiber.Ctx) bool {
+			return gormDB.Exec("SELECT 1").Error == nil
+		},
+	}))
 
 	// Use Fiber Rate API Limiter
 	if !common.EnvironmentConfig.IsTest() && common.EnvironmentConfig.MaxRequests != 0 {

--- a/status_test.go
+++ b/status_test.go
@@ -4,8 +4,20 @@ import (
 	"testing"
 )
 
-func TestStatusEndpoints(t *testing.T) {
+func TestHealthEndpoints(t *testing.T) {
 	tests := []TestCase{
+		{
+			query:               "GET /livez",
+			expectedCode:        200,
+			expectedBody:        "OK",
+			expectedContentType: "text/plain; charset=utf-8",
+		},
+		{
+			query:               "GET /readyz",
+			expectedCode:        200,
+			expectedBody:        "OK",
+			expectedContentType: "text/plain; charset=utf-8",
+		},
 		{
 			query:               "GET /v1/status",
 			expectedCode:        204,


### PR DESCRIPTION
/livez and /readyz can be used by k8s to tell liveness (process alive) from readiness (DB reachable).