### PR TITLE
fix: regression in building the production Docker image

### DIFF
--- a/internal/common/dberr.go
+++ b/internal/common/dberr.go
@@ -2,10 +2,8 @@ package common
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	sqlite3 "github.com/mattn/go-sqlite3"
 )
 
 // pgConstraintToAPI maps PostgreSQL unique index names to API field names.
@@ -32,23 +30,8 @@ var sqliteColToAPI = map[string]string{ //nolint:gochecknoglobals
 // it (e.g. "alternativeId", "codeHosting.url") if it is, or a pointer to an
 // empty string if the field cannot be determined.
 func DuplicateField(err error) *string {
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) {
-		if sqliteErr.ExtendedCode != sqlite3.ErrConstraintUnique &&
-			sqliteErr.ExtendedCode != sqlite3.ErrConstraintPrimaryKey {
-			return nil
-		}
-
-		msg := sqliteErr.Error()
-		if _, tableCol, ok := strings.Cut(msg, "UNIQUE constraint failed: "); ok {
-			field := sqliteColToAPI[tableCol]
-
-			return &field
-		}
-
-		empty := ""
-
-		return &empty
+	if field := duplicateFieldSQLite(err); field != nil {
+		return field
 	}
 
 	var pgErr *pgconn.PgError

--- a/internal/common/dberr_nosqlite.go
+++ b/internal/common/dberr_nosqlite.go
@@ -1,0 +1,7 @@
+//go:build !cgo
+
+package common
+
+func duplicateFieldSQLite(_ error) *string {
+	return nil
+}

--- a/internal/common/dberr_sqlite.go
+++ b/internal/common/dberr_sqlite.go
@@ -1,0 +1,33 @@
+//go:build cgo
+
+package common
+
+import (
+	"errors"
+	"strings"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+func duplicateFieldSQLite(err error) *string {
+	var sqliteErr sqlite3.Error
+	if !errors.As(err, &sqliteErr) {
+		return nil
+	}
+
+	if sqliteErr.ExtendedCode != sqlite3.ErrConstraintUnique &&
+		sqliteErr.ExtendedCode != sqlite3.ErrConstraintPrimaryKey {
+		return nil
+	}
+
+	msg := sqliteErr.Error()
+	if _, tableCol, ok := strings.Cut(msg, "UNIQUE constraint failed: "); ok {
+		field := sqliteColToAPI[tableCol]
+
+		return &field
+	}
+
+	empty := ""
+
+	return &empty
+}


### PR DESCRIPTION
The image failed building because of a bug introduced by 06d96335f7f.

The release build uses CGO_ENABLED=0, which makes go-sqlite3 symbols undefined and breaks compilation. SQLite is only used in tests, so the sqlite3 specific branch of DuplicateField is dead code in production.