### PR TITLE
chore: rename to software-catalog-api in README and publiccode.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable no-inline-html -->
 
-<h1 align="center">Developers Italia API</h1>
+<h1 align="center">Software Catalog API</h1>
 
 <p align="center">
-  <img width="200" src=".github/logo.png" alt="developers-italia-api logo">
+  <img width="200" src=".github/logo.png" alt="software-catalog-api logo">
 </p>
 
 <p align="center">
@@ -31,9 +31,12 @@
 </div>
 
 <p align="center">
-  <strong>Developers Italia API</strong> is the RESTful API of the Free and Open Source software catalog
-  aimed at Italian Public Administrations.
+  <strong>Software Catalog API</strong> is a RESTful API for public software catalogs.
+  It powers national open source catalogs for public administrations:
 </p>
+
+- 🇮🇹 [developers.italia.it](https://developers.italia.it)
+- 🇨🇭 [swiss/oss-catalog](https://github.com/swiss/oss-catalog)
 
 ## Requirements
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -6,7 +6,7 @@ publiccodeYmlVersion: "0.4"
 categories:
   - data-collection
 description:
-  it:
+  en:
     apiDocumentation: "https://developers.italia.it/it/api/developers-italia"
     features:
       - RESTful API Design
@@ -15,16 +15,11 @@ description:
       - Containerization support
       - Helm chart available
     longDescription: |
-      **developers-italia-api** is a RESTful API for the free and open-source
-      software catalog aimed at Italian public administrations. This API serves
-      as a crucial tool in managing and accessing the software catalog,
-      providing a streamlined and efficient way for public administrations and
-      developers to interact with the repository. It's built with a focus on
-      ease of use and reliability, ensuring that users can effectively leverage
-      the catalog for their software needs.
+      **software-catalog-api** is a RESTful API for public software catalogs.
+      It powers developers.italia.it and can be deployed as a standalone
+      instance for any public software catalog.
     shortDescription: |-
-      RESTful API for the free and open-source software catalog aimed at Italian
-      public administrations.
+      RESTful API for public software catalogs.
 developmentStatus: stable
 it:
   conforme:
@@ -51,7 +46,7 @@ maintenance:
   contacts:
     - name: Fabio Bonelli
   type: community
-name: developers-italia-api
+name: software-catalog-api
 platforms:
   - web
 dependsOn:


### PR DESCRIPTION
See #270.