### PR TITLE
feat: add /software/:id/analysis endpoint, remove analysis from softw…

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -39,21 +39,19 @@ type CodeHosting struct {
 }
 
 type SoftwarePost struct {
-	URL           string       `json:"url" validate:"required,url"`
-	Aliases       []string     `json:"aliases" validate:"dive,url"`
-	PubliccodeYml string       `json:"publiccodeYml" validate:"required"`
-	Active        *bool        `json:"active"`
-	Vitality      *string      `json:"vitality"`
-	Analysis      AnalysisData `json:"analysis"`
+	URL           string   `json:"url" validate:"required,url"`
+	Aliases       []string `json:"aliases" validate:"dive,url"`
+	PubliccodeYml string   `json:"publiccodeYml" validate:"required"`
+	Active        *bool    `json:"active"`
+	Vitality      *string  `json:"vitality"`
 }
 
 type SoftwarePatch struct {
-	URL           *string      `json:"url" validate:"omitempty,url"`
-	Aliases       *[]string    `json:"aliases" validate:"omitempty,dive,url"`
-	PubliccodeYml *string      `json:"publiccodeYml"`
-	Active        *bool        `json:"active"`
-	Vitality      *string      `json:"vitality"`
-	Analysis      AnalysisData `json:"analysis"`
+	URL           *string   `json:"url" validate:"omitempty,url"`
+	Aliases       *[]string `json:"aliases" validate:"omitempty,dive,url"`
+	PubliccodeYml *string   `json:"publiccodeYml"`
+	Active        *bool     `json:"active"`
+	Vitality      *string   `json:"vitality"`
 }
 
 type Log struct {

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -23,6 +23,8 @@ type SoftwareInterface interface {
 	PostSoftware(ctx *fiber.Ctx) error
 	PatchSoftware(ctx *fiber.Ctx) error
 	DeleteSoftware(ctx *fiber.Ctx) error
+	GetSoftwareAnalysis(ctx *fiber.Ctx) error
+	PatchSoftwareAnalysis(ctx *fiber.Ctx) error
 }
 
 type Software struct {
@@ -146,11 +148,6 @@ func (p *Software) PostSoftware(ctx *fiber.Ctx) error {
 		return err //nolint:wrapcheck
 	}
 
-	analysis, err := common.WithTimestamps(softwareReq.Analysis, time.Now())
-	if err != nil {
-		return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
-	}
-
 	aliases := []models.SoftwareURL{}
 	for _, u := range softwareReq.Aliases {
 		aliases = append(aliases, models.SoftwareURL{ID: utils.UUIDv4(), URL: common.NormalizeURL(u)})
@@ -168,7 +165,6 @@ func (p *Software) PostSoftware(ctx *fiber.Ctx) error {
 		PubliccodeYml: softwareReq.PubliccodeYml,
 		Active:        softwareReq.Active,
 		Vitality:      softwareReq.Vitality,
-		Analysis:      analysis,
 	}
 
 	if err := p.db.Create(&software).Error; err != nil {
@@ -229,15 +225,6 @@ func (p *Software) PatchSoftware(ctx *fiber.Ctx) error { //nolint:funlen,cyclop
 	err = json.Unmarshal(updatedJSON, &updatedSoftware)
 	if err != nil {
 		return common.Error(fiber.StatusInternalServerError, errMsg, err.Error())
-	}
-
-	updatedSoftware.Analysis, err = injectTouchedAnalysis(
-		software.Analysis,
-		updatedSoftware.Analysis,
-		time.Now(),
-	)
-	if err != nil {
-		return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
 	}
 
 	updatedSoftware.URL.URL = common.NormalizeURL(updatedSoftware.URL.URL)
@@ -404,6 +391,59 @@ func syncAliases( //nolint:cyclop // mostly error handling ifs
 	}
 
 	return &updatedURL, aliases, nil
+}
+
+// GetSoftwareAnalysis returns the analysis data for the software with the given ID.
+func (p *Software) GetSoftwareAnalysis(ctx *fiber.Ctx) error {
+	const errMsg = "can't get Software analysis"
+
+	software := models.Software{}
+
+	if err := p.db.First(&software, "id = ?", ctx.Params("id")).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, errMsg, "Software was not found")
+		}
+
+		return common.InternalServerError(errMsg)
+	}
+
+	if software.Analysis == nil {
+		return ctx.JSON(common.AnalysisData{})
+	}
+
+	return ctx.JSON(software.Analysis)
+}
+
+// PatchSoftwareAnalysis merges the incoming analysis namespaces into the stored analysis.
+// The request body is an AnalysisData object (namespace → arbitrary JSON with "v" field).
+func (p *Software) PatchSoftwareAnalysis(ctx *fiber.Ctx) error {
+	const errMsg = "can't update Software analysis"
+
+	software := models.Software{}
+
+	if err := p.db.First(&software, "id = ?", ctx.Params("id")).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, errMsg, "Software was not found")
+		}
+
+		return common.InternalServerError(errMsg)
+	}
+
+	var incoming common.AnalysisData
+	if err := ctx.BodyParser(&incoming); err != nil {
+		return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+	}
+
+	merged, err := injectTouchedAnalysis(software.Analysis, incoming, time.Now())
+	if err != nil {
+		return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+	}
+
+	if err := p.db.Model(&software).Update("analysis", merged).Error; err != nil {
+		return common.InternalServerError(errMsg)
+	}
+
+	return ctx.JSON(merged)
 }
 
 // injectTouchedAnalysis validates and injects "t" only into namespaces that

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -78,7 +78,7 @@ type Software struct {
 	Logs          []Log               `json:"-" gorm:"polymorphic:Entity;"`
 	Active        *bool               `json:"active" gorm:"default:true;not null"`
 	Vitality      *string             `json:"vitality"`
-	Analysis      common.AnalysisData `json:"analysis" gorm:"type:jsonb"`
+	Analysis      common.AnalysisData `json:"-" gorm:"type:jsonb"`
 	CreatedAt     time.Time           `json:"createdAt" gorm:"index"`
 	UpdatedAt     time.Time           `json:"updatedAt"`
 }

--- a/main.go
+++ b/main.go
@@ -152,6 +152,8 @@ func setupHandlers(app *fiber.App, gormDB *gorm.DB) {
 	v1.Post("/software", softwareHandler.PostSoftware)
 	v1.Patch("/software/:id", softwareHandler.PatchSoftware)
 	v1.Delete("/software/:id", softwareHandler.DeleteSoftware)
+	v1.Get("/software/:id/analysis", softwareHandler.GetSoftwareAnalysis)
+	v1.Patch("/software/:id/analysis", softwareHandler.PatchSoftwareAnalysis)
 
 	v1.Get("/logs", logHandler.GetLogs)
 	v1.Get("/logs/:id<guid>", logHandler.GetLog)

--- a/software_test.go
+++ b/software_test.go
@@ -42,7 +42,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, true, firstSoftware["active"])
 
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, true, firstSoftware["active"])
 
 				assertTimestamps(t, firstSoftware)
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, firstSoftware["id"])
 				assertTimestamps(t, firstSoftware)
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, "2014-05-01T00:00:00Z", firstSoftware["createdAt"])
 				assert.Equal(t, "2014-05-01T00:00:00Z", firstSoftware["updatedAt"])
 
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 			},
 		},
 		{
@@ -307,7 +307,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 			},
 		},
 		{
@@ -325,7 +325,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 			},
 		},
 
@@ -351,7 +351,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, true, response["active"])
 
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 
 			},
 		},
@@ -379,7 +379,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 
 			},
 		},
@@ -423,33 +423,14 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "analysis")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
 
 			},
 		},
 		{
-			description: "POST software with analysis field",
+			description: "POST software with analysis field is rejected",
 			query:       "POST /v1/software",
 			body:        `{"publiccodeYml": "-", "url": "https://analysis.example.org", "analysis": {"badges": {"v": 1, "score": 90}}}`,
-			headers: map[string][]string{
-				"Authorization": {goodToken},
-				"Content-Type":  {"application/json"},
-			},
-			expectedCode:        200,
-			expectedContentType: "application/json",
-			validateFunc: func(t *testing.T, response map[string]interface{}) {
-				analysis := response["analysis"].(map[string]interface{})
-				badges := analysis["badges"].(map[string]interface{})
-
-				assert.Equal(t, float64(1), badges["v"])
-				assert.Equal(t, float64(90), badges["score"])
-				assertRFC3339(t, badges["t"])
-			},
-		},
-		{
-			description: "POST software with analysis missing v field",
-			query:       "POST /v1/software",
-			body:        `{"publiccodeYml": "-", "url": "https://analysis-nov.example.org", "analysis": {"badges": {"score": 90}}}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -791,39 +772,6 @@ func TestSoftwareEndpoints(t *testing.T) {
 				updated := assertRFC3339(t, response["updatedAt"])
 
 				assert.Greater(t, updated, created)
-			},
-		},
-		{
-			description: "PATCH software, analysis namespace",
-			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
-			body:        `{"analysis": {"badges": {"v": 1, "score": 75}}}`,
-			headers: map[string][]string{
-				"Authorization": {goodToken},
-				"Content-Type":  {"application/json"},
-			},
-			expectedCode:        200,
-			expectedContentType: "application/json",
-			validateFunc: func(t *testing.T, response map[string]interface{}) {
-				analysis := response["analysis"].(map[string]interface{})
-				badges := analysis["badges"].(map[string]interface{})
-
-				assert.Equal(t, float64(1), badges["v"])
-				assert.Equal(t, float64(75), badges["score"])
-				assertRFC3339(t, badges["t"])
-			},
-		},
-		{
-			description: "PATCH software, analysis namespace missing v",
-			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
-			body:        `{"analysis": {"badges": {"score": 75}}}`,
-			headers: map[string][]string{
-				"Authorization": {goodToken},
-				"Content-Type":  {"application/json"},
-			},
-			expectedCode:        422,
-			expectedContentType: "application/problem+json",
-			validateFunc: func(t *testing.T, response map[string]interface{}) {
-				assert.Equal(t, "can't update Software", response["title"])
 			},
 		},
 		{
@@ -1482,7 +1430,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 }
 
 func TestSoftwarePostDBChecks(t *testing.T) {
-	t.Run("POST software with analysis persists to DB", func(t *testing.T) {
+	t.Run("POST software does not accept analysis field", func(t *testing.T) {
 		loadFixtures(t)
 
 		body := `{"publiccodeYml": "-", "url": "https://analysis-db.example.org", "analysis": {"badges": {"v": 1, "score": 90}}}`
@@ -1495,21 +1443,7 @@ func TestSoftwarePostDBChecks(t *testing.T) {
 
 		res, err := app.Test(req, -1)
 		require.NoError(t, err)
-		assert.Equal(t, 200, res.StatusCode)
-
-		var response map[string]interface{}
-		require.NoError(t, json.NewDecoder(res.Body).Decode(&response))
-		softwareID := response["id"].(string)
-
-		raw := dbValue(t, "software", "analysis", "id", softwareID)
-
-		var analysis map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(raw), &analysis))
-
-		badges := analysis["badges"].(map[string]interface{})
-		assert.Equal(t, float64(1), badges["v"])
-		assert.Equal(t, float64(90), badges["score"])
-		assertRFC3339(t, badges["t"])
+		assert.Equal(t, 422, res.StatusCode)
 	})
 }
 
@@ -1540,7 +1474,7 @@ func TestSoftwarePatchDBChecks(t *testing.T) {
 		assert.Equal(t, 3, dbCount(t, "software_urls", "software_id", softwareID))
 	})
 
-	t.Run("PATCH software with analysis persists to DB", func(t *testing.T) {
+	t.Run("PATCH software does not accept analysis field", func(t *testing.T) {
 		loadFixtures(t)
 
 		const softwareID = "59803fb7-8eec-4fe5-a354-8926009c364a"
@@ -1555,12 +1489,106 @@ func TestSoftwarePatchDBChecks(t *testing.T) {
 
 		res, err := app.Test(req, -1)
 		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
+}
+
+func TestSoftwareAnalysisEndpoints(t *testing.T) {
+	const softwareID = "59803fb7-8eec-4fe5-a354-8926009c364a"
+	const missingID = "00000000-0000-0000-0000-000000000000"
+
+	tests := []TestCase{
+		{
+			description:         "GET analysis on software with no analysis returns empty object",
+			query:               "GET /v1/software/" + softwareID + "/analysis",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Empty(t, response)
+			},
+		},
+		{
+			description: "PATCH analysis adds namespace with timestamp",
+			query:       "PATCH /v1/software/" + softwareID + "/analysis",
+			body:        `{"badges": {"v": 1, "score": 90}}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				badges := response["badges"].(map[string]interface{})
+
+				assert.Equal(t, float64(1), badges["v"])
+				assert.Equal(t, float64(90), badges["score"])
+				assertRFC3339(t, badges["t"])
+			},
+		},
+		{
+			description: "PATCH analysis missing v field returns 422",
+			query:       "PATCH /v1/software/" + softwareID + "/analysis",
+			body:        `{"badges": {"score": 90}}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't update Software analysis", response["title"])
+			},
+		},
+		{
+			description:         "GET analysis on nonexistent software returns 404",
+			query:               "GET /v1/software/" + missingID + "/analysis",
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't get Software analysis", response["title"])
+			},
+		},
+		{
+			description: "PATCH analysis on nonexistent software returns 404",
+			query:       "PATCH /v1/software/" + missingID + "/analysis",
+			body:        `{"badges": {"v": 1}}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't update Software analysis", response["title"])
+			},
+		},
+	}
+
+	runTestCases(t, tests)
+}
+
+func TestSoftwareAnalysisDBChecks(t *testing.T) {
+	t.Run("PATCH analysis persists to DB", func(t *testing.T) {
+		loadFixtures(t)
+
+		const softwareID = "59803fb7-8eec-4fe5-a354-8926009c364a"
+
+		body := `{"badges": {"v": 1, "score": 75}}`
+		req, err := http.NewRequest("PATCH", "/v1/software/"+softwareID+"/analysis", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
 		assert.Equal(t, 200, res.StatusCode)
 
 		raw := dbValue(t, "software", "analysis", "id", softwareID)
 
 		var analysis map[string]interface{}
-		require.NoError(t, json.Unmarshal([]byte(raw), &analysis))
+		require.NoError(t, json.NewDecoder(strings.NewReader(raw)).Decode(&analysis))
 
 		badges := analysis["badges"].(map[string]interface{})
 		assert.Equal(t, float64(1), badges["v"])


### PR DESCRIPTION
…are resource

Thinking about it more, analysis probably doesn't belong in the software resource (5d3be22). It's written by external tools, not publishers, and there's no reason to dump it in every GET /software response.