### PR TITLE
feat: add catalogs resource

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	italiaID = "a8e5e6d7-0b1c-4f2a-8e3d-9c4b5a6f7e8d"
+	swissID  = "b9f6f7e8-1c2d-4f3b-9f4e-0d5c6b7a8f9e"
+)
+
+func TestCatalogEndpoints(t *testing.T) {
+	tests := []TestCase{
+		// GET /catalogs
+		{
+			description:         "GET catalogs",
+			query:               "GET /v1/catalogs",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 2, len(data))
+
+				first := data[0]
+				assertUUID(t, first["id"])
+				assertTimestamps(t, first)
+				assertOnlyKeys(t, first, "id", "name", "alternativeId", "active", "createdAt", "updatedAt")
+			},
+		},
+
+		// GET /catalogs/:id
+		{
+			description:         "GET catalog by id",
+			query:               "GET /v1/catalogs/" + italiaID,
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, italiaID, response["id"])
+				assert.Equal(t, "Italian Catalog", response["name"])
+				assert.Equal(t, "italia", response["alternativeId"])
+				assertOnlyKeys(t, response, "id", "name", "alternativeId", "active", "createdAt", "updatedAt")
+			},
+		},
+		{
+			description:         "GET catalog by alternativeId",
+			query:               "GET /v1/catalogs/swiss",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, swissID, response["id"])
+				assert.Equal(t, "Swiss Catalog", response["name"])
+			},
+		},
+		{
+			description:         "GET catalog not found",
+			query:               "GET /v1/catalogs/nonexistent",
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't get Catalog","detail":"Catalog was not found","status":404}`,
+		},
+		{
+			description:         "GET root catalog (∅) returns 404 — root is implicit",
+			query:               "GET /v1/catalogs/%E2%88%85",
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't get Catalog","detail":"Catalog was not found","status":404}`,
+		},
+
+		// POST /catalogs
+		{
+			description: "POST catalog",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "New Catalog"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assertUUID(t, response["id"])
+				assert.Equal(t, "New Catalog", response["name"])
+				assertOnlyKeys(t, response, "id", "name", "active", "createdAt", "updatedAt")
+			},
+		},
+		{
+			description: "POST catalog with alternativeId",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "Another Catalog", "alternativeId": "another"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "another", response["alternativeId"])
+			},
+		},
+		{
+			description: "POST catalog duplicate alternativeId",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "Dup", "alternativeId": "italia"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        409,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't create Catalog","detail":"already exists","status":409}`,
+		},
+		{
+			description: "POST catalog missing name",
+			query:       "POST /v1/catalogs",
+			body:        `{}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't create Catalog","detail":"invalid format: name is required","status":422,"validationErrors":[{"field":"name","rule":"required","value":""}]}`,
+		},
+		{
+			description:         "POST catalog - no token",
+			query:               "POST /v1/catalogs",
+			body:                `{"name": "Unauth"}`,
+			expectedCode:        401,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
+		},
+
+		// PATCH /catalogs/:id
+		{
+			description: "PATCH catalog",
+			query:       "PATCH /v1/catalogs/" + italiaID,
+			body:        `{"name": "Updated Italian Catalog"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, italiaID, response["id"])
+				assert.Equal(t, "Updated Italian Catalog", response["name"])
+			},
+		},
+		{
+			description: "PATCH catalog - root returns 404",
+			query:       "PATCH /v1/catalogs/%E2%88%85",
+			body:        `{"name": "x"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't update Catalog","detail":"Catalog was not found","status":404}`,
+		},
+		{
+			description:         "PATCH catalog - no token",
+			query:               "PATCH /v1/catalogs/" + italiaID,
+			body:                `{"name": "x"}`,
+			expectedCode:        401,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
+		},
+
+		// DELETE /catalogs/:id
+		{
+			description: "DELETE catalog - 409 if has publishers",
+			query:       "DELETE /v1/catalogs/" + italiaID,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+			},
+			expectedCode:        409,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't delete Catalog","detail":"Catalog still has associated publishers or software","status":409}`,
+		},
+		{
+			description: "DELETE catalog - root returns 404",
+			query:       "DELETE /v1/catalogs/%E2%88%85",
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+			},
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't delete Catalog","detail":"Catalog was not found","status":404}`,
+		},
+		{
+			description:         "DELETE catalog - no token",
+			query:               "DELETE /v1/catalogs/" + italiaID,
+			expectedCode:        401,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"token authentication failed","status":401}`,
+		},
+
+		// GET /catalogs/:id/publishers
+		{
+			description:         "GET catalog publishers",
+			query:               "GET /v1/catalogs/" + italiaID + "/publishers",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 1, len(data))
+				assert.Equal(t, "2ded32eb-c45e-4167-9166-a44e18b8adde", data[0]["id"])
+			},
+		},
+		{
+			description:         "GET catalog publishers by alternativeId",
+			query:               "GET /v1/catalogs/swiss/publishers",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 1, len(data))
+				assert.Equal(t, "47807e0c-0613-4aea-9917-5455cc6eddad", data[0]["id"])
+			},
+		},
+		{
+			description:         "GET root catalog publishers (∅)",
+			query:               "GET /v1/catalogs/%E2%88%85/publishers",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				// All publishers except the 2 assigned to named catalogs, minus the inactive one
+				assert.Equal(t, 25, len(data))
+			},
+		},
+		{
+			description:         "GET publishers for nonexistent catalog",
+			query:               "GET /v1/catalogs/nonexistent/publishers",
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't get Publishers","detail":"Catalog was not found","status":404}`,
+		},
+
+		// GET /catalogs/:id/software
+		{
+			description:         "GET catalog software",
+			query:               "GET /v1/catalogs/" + italiaID + "/software",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 1, len(data))
+				assert.Equal(t, "c353756e-8597-4e46-a99b-7da2e141603b", data[0]["id"])
+			},
+		},
+		{
+			description:         "GET root catalog software (∅)",
+			query:               "GET /v1/catalogs/%E2%88%85/software",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				// All active software except the 2 assigned to named catalogs
+				assert.Equal(t, 25, len(data))
+			},
+		},
+		{
+			description:         "GET software for nonexistent catalog",
+			query:               "GET /v1/catalogs/nonexistent/software",
+			expectedCode:        404,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't get Software","detail":"Catalog was not found","status":404}`,
+		},
+	}
+
+	runTestCases(t, tests)
+}
+
+func TestCatalogDeleteDBChecks(t *testing.T) {
+	t.Run("DELETE catalog removes it from DB when empty", func(t *testing.T) {
+		loadFixtures(t)
+
+		// Create an empty catalog to delete
+		body := `{"name": "To Delete"}`
+		req, err := http.NewRequest("POST", "/v1/catalogs", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		var created map[string]interface{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&created))
+		catalogID := created["id"].(string)
+
+		req, err = http.NewRequest("DELETE", "/v1/catalogs/"+catalogID, nil)
+		require.NoError(t, err)
+		req.Header = map[string][]string{"Authorization": {goodToken}}
+
+		res, err = app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 204, res.StatusCode)
+
+		assert.Equal(t, 0, dbCount(t, "catalogs", "id", catalogID))
+	})
+}

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -17,7 +17,20 @@ func NormalizeURL(rawURL string) string {
 	return normalized
 }
 
+type CatalogPost struct {
+	Name          string  `json:"name" validate:"required,min=1,max=255"`
+	AlternativeID *string `json:"alternativeId" validate:"omitempty,min=1,max=255"`
+	Active        *bool   `json:"active"`
+}
+
+type CatalogPatch struct {
+	Name          *string `json:"name" validate:"omitempty,min=1,max=255"`
+	AlternativeID *string `json:"alternativeId" validate:"omitempty,max=255"`
+	Active        *bool   `json:"active"`
+}
+
 type PublisherPost struct {
+	CatalogID     *string       `json:"catalogId" validate:"omitempty,min=1,max=36"`
 	CodeHosting   []CodeHosting `json:"codeHosting" validate:"required,gt=0,dive"`
 	Description   string        `json:"description" validate:"required"`
 	Email         *string       `json:"email" validate:"omitempty,email"`
@@ -26,6 +39,7 @@ type PublisherPost struct {
 }
 
 type PublisherPatch struct {
+	CatalogID     *string        `json:"catalogId" validate:"omitempty,max=36"`
 	CodeHosting   *[]CodeHosting `json:"codeHosting" validate:"omitempty,gt=0,dive"`
 	Description   *string        `json:"description"`
 	Email         *string        `json:"email" validate:"omitempty,email"`
@@ -39,6 +53,7 @@ type CodeHosting struct {
 }
 
 type SoftwarePost struct {
+	CatalogID     *string  `json:"catalogId" validate:"omitempty,min=1,max=36"`
 	URL           string   `json:"url" validate:"required,url"`
 	Aliases       []string `json:"aliases" validate:"dive,url"`
 	PubliccodeYml string   `json:"publiccodeYml" validate:"required"`
@@ -47,6 +62,7 @@ type SoftwarePost struct {
 }
 
 type SoftwarePatch struct {
+	CatalogID     *string   `json:"catalogId" validate:"omitempty,max=36"`
 	URL           *string   `json:"url" validate:"omitempty,url"`
 	Aliases       *[]string `json:"aliases" validate:"omitempty,dive,url"`
 	PubliccodeYml *string   `json:"publiccodeYml"`

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -38,6 +38,7 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 	}
 
 	if err = database.AutoMigrate(
+		&models.Catalog{},
 		&models.Publisher{},
 		&models.Event{},
 		&models.CodeHosting{},

--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -1,0 +1,387 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/utils"
+	"github.com/italia/developers-italia-api/internal/common"
+	"github.com/italia/developers-italia-api/internal/handlers/general"
+	"github.com/italia/developers-italia-api/internal/models"
+	"gorm.io/gorm"
+)
+
+// rootCatalogID is the path parameter value that refers to the implicit root
+// catalog (resources with catalog_id IS NULL).
+const rootCatalogID = "∅"
+
+type CatalogInterface interface {
+	GetCatalogs(ctx *fiber.Ctx) error
+	GetCatalog(ctx *fiber.Ctx) error
+	PostCatalog(ctx *fiber.Ctx) error
+	PatchCatalog(ctx *fiber.Ctx) error
+	DeleteCatalog(ctx *fiber.Ctx) error
+
+	GetCatalogPublishers(ctx *fiber.Ctx) error
+	GetCatalogSoftware(ctx *fiber.Ctx) error
+}
+
+type Catalog struct {
+	db *gorm.DB
+}
+
+func NewCatalog(db *gorm.DB) *Catalog {
+	return &Catalog{db: db}
+}
+
+// catalogScope returns a GORM scope that filters by catalog.
+// nil catalog means root (catalog_id IS NULL).
+func catalogScope(catalog *models.Catalog) func(*gorm.DB) *gorm.DB {
+	return func(db *gorm.DB) *gorm.DB {
+		if catalog == nil {
+			return db.Where("catalog_id IS NULL")
+		}
+
+		return db.Where("catalog_id = ?", catalog.ID)
+	}
+}
+
+// GetCatalogs gets the list of all catalogs.
+func (c *Catalog) GetCatalogs(ctx *fiber.Ctx) error {
+	var catalogs []models.Catalog
+
+	stmt, err := general.Clauses(ctx, c.db, "")
+	if err != nil {
+		return common.Error(fiber.StatusUnprocessableEntity, "can't get Catalogs", err.Error())
+	}
+
+	if all := ctx.QueryBool("all", false); !all {
+		stmt = stmt.Scopes(models.Active)
+	}
+
+	paginator := general.NewPaginator(ctx)
+
+	result, cursor, err := paginator.Paginate(stmt, &catalogs)
+	if err != nil {
+		return common.Error(
+			fiber.StatusUnprocessableEntity,
+			"can't get Catalogs",
+			"wrong cursor format in page[after] or page[before]",
+		)
+	}
+
+	if result.Error != nil {
+		return common.Error(
+			fiber.StatusInternalServerError,
+			"can't get Catalogs",
+			fiber.ErrInternalServerError.Message,
+		)
+	}
+
+	return ctx.JSON(fiber.Map{"data": &catalogs, "links": general.PaginationLinks(cursor)})
+}
+
+// GetCatalog gets the catalog with the given id.
+func (c *Catalog) GetCatalog(ctx *fiber.Ctx) error {
+	id, _ := url.PathUnescape(ctx.Params("id"))
+
+	catalog, err := c.resolveCatalog(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, "can't get Catalog", "Catalog was not found")
+		}
+
+		return common.Error(fiber.StatusInternalServerError, "can't get Catalog", fiber.ErrInternalServerError.Message)
+	}
+
+	if catalog == nil {
+		// Root catalog: return a synthetic representation.
+		return common.Error(fiber.StatusNotFound, "can't get Catalog", "Catalog was not found")
+	}
+
+	return ctx.JSON(catalog)
+}
+
+// PostCatalog creates a new catalog.
+func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
+	const errMsg = "can't create Catalog"
+
+	request := new(common.CatalogPost)
+
+	if err := common.ValidateRequestEntity(ctx, request, errMsg); err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	catalog := &models.Catalog{
+		ID:            utils.UUIDv4(),
+		Name:          request.Name,
+		AlternativeID: request.AlternativeID,
+		Active:        request.Active,
+	}
+
+	if err := c.db.Create(catalog).Error; err != nil {
+		if field := common.DuplicateField(err); field != nil {
+			detail := alreadyExists
+			if *field != "" {
+				detail = *field + " " + alreadyExists
+			}
+
+			return common.Error(fiber.StatusConflict, errMsg, detail)
+		}
+
+		return common.Error(fiber.StatusInternalServerError, errMsg, fiber.ErrInternalServerError.Message)
+	}
+
+	return ctx.JSON(catalog)
+}
+
+// PatchCatalog updates the catalog with the given id.
+func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
+	const errMsg = "can't update Catalog"
+
+	catalogID, _ := url.PathUnescape(ctx.Params("id"))
+
+	if catalogID == rootCatalogID {
+		return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
+	}
+
+	catalog := models.Catalog{}
+
+	if err := c.db.First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
+		}
+
+		return common.Error(fiber.StatusInternalServerError, errMsg, fiber.ErrInternalServerError.Message)
+	}
+
+	catalogJSON, err := json.Marshal(&catalog)
+	if err != nil {
+		return common.Error(fiber.StatusInternalServerError, errMsg, err.Error())
+	}
+
+	var updatedJSON []byte
+
+	switch ctx.Get(fiber.HeaderContentType) {
+	case contentTypeJSONPatch:
+		patch, err := jsonpatch.DecodePatch(ctx.Body())
+		if err != nil {
+			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
+		}
+
+		updatedJSON, err = patch.Apply(catalogJSON)
+		if err != nil {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+		}
+
+	default:
+		catalogReq := new(common.CatalogPatch)
+
+		if err := common.ValidateRequestEntity(ctx, catalogReq, errMsg); err != nil {
+			return err //nolint:wrapcheck
+		}
+
+		updatedJSON, err = jsonpatch.MergePatch(catalogJSON, ctx.Body())
+		if err != nil {
+			return common.Error(fiber.StatusInternalServerError, errMsg, err.Error())
+		}
+	}
+
+	var updatedCatalog models.Catalog
+
+	if err := json.Unmarshal(updatedJSON, &updatedCatalog); err != nil {
+		return common.Error(fiber.StatusInternalServerError, errMsg, err.Error())
+	}
+
+	updatedCatalog.ID = catalog.ID
+
+	if err := c.db.Updates(&updatedCatalog).Error; err != nil {
+		if field := common.DuplicateField(err); field != nil {
+			detail := alreadyExists
+			if *field != "" {
+				detail = *field + " " + alreadyExists
+			}
+
+			return common.Error(fiber.StatusConflict, errMsg, detail)
+		}
+
+		return common.Error(fiber.StatusInternalServerError, errMsg, fiber.ErrInternalServerError.Message)
+	}
+
+	return ctx.JSON(&updatedCatalog)
+}
+
+// DeleteCatalog deletes the catalog with the given id.
+// Returns 409 if the catalog still has associated publishers or software.
+func (c *Catalog) DeleteCatalog(ctx *fiber.Ctx) error {
+	const errMsg = "can't delete Catalog"
+
+	catalogID, _ := url.PathUnescape(ctx.Params("id"))
+
+	if catalogID == rootCatalogID {
+		return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
+	}
+
+	catalog := models.Catalog{}
+
+	if err := c.db.First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
+		}
+
+		return common.Error(fiber.StatusInternalServerError, errMsg, fiber.ErrInternalServerError.Message)
+	}
+
+	var conflictErr error
+
+	if err := c.db.Transaction(func(tran *gorm.DB) error {
+		var publisherCount, softwareCount int64
+
+		if err := tran.Model(&models.Publisher{}).
+			Where("catalog_id = ?", catalog.ID).Count(&publisherCount).Error; err != nil {
+			return err
+		}
+
+		if err := tran.Model(&models.Software{}).Where("catalog_id = ?", catalog.ID).Count(&softwareCount).Error; err != nil {
+			return err
+		}
+
+		if publisherCount > 0 || softwareCount > 0 {
+			conflictErr = common.Error(fiber.StatusConflict, errMsg, "Catalog still has associated publishers or software")
+
+			return nil
+		}
+
+		return tran.Where("id = ?", catalog.ID).Delete(&models.Catalog{}).Error
+	}); err != nil {
+		return common.Error(fiber.StatusInternalServerError, errMsg, "db error")
+	}
+
+	if conflictErr != nil {
+		return conflictErr //nolint:wrapcheck
+	}
+
+	return ctx.SendStatus(fiber.StatusNoContent)
+}
+
+// GetCatalogPublishers lists publishers belonging to the given catalog.
+func (c *Catalog) GetCatalogPublishers(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+
+	catalog, err := c.resolveCatalog(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, "can't get Publishers", "Catalog was not found")
+		}
+
+		return common.Error(fiber.StatusInternalServerError, "can't get Publishers", fiber.ErrInternalServerError.Message)
+	}
+
+	var publishers []models.Publisher
+
+	stmt := c.db.Preload("CodeHosting").Scopes(catalogScope(catalog))
+
+	stmt, err = general.Clauses(ctx, stmt, "")
+	if err != nil {
+		return common.Error(fiber.StatusUnprocessableEntity, "can't get Publishers", err.Error())
+	}
+
+	if all := ctx.QueryBool("all", false); !all {
+		stmt = stmt.Scopes(models.Active)
+	}
+
+	paginator := general.NewPaginator(ctx)
+
+	result, cursor, err := paginator.Paginate(stmt, &publishers)
+	if err != nil {
+		return common.Error(
+			fiber.StatusUnprocessableEntity,
+			"can't get Publishers",
+			"wrong cursor format in page[after] or page[before]",
+		)
+	}
+
+	if result.Error != nil {
+		return common.Error(
+			fiber.StatusInternalServerError,
+			"can't get Publishers",
+			fiber.ErrInternalServerError.Message,
+		)
+	}
+
+	return ctx.JSON(fiber.Map{"data": &publishers, "links": general.PaginationLinks(cursor)})
+}
+
+// GetCatalogSoftware lists software belonging to the given catalog.
+func (c *Catalog) GetCatalogSoftware(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+
+	catalog, err := c.resolveCatalog(id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return common.Error(fiber.StatusNotFound, "can't get Software", "Catalog was not found")
+		}
+
+		return common.Error(fiber.StatusInternalServerError, "can't get Software", fiber.ErrInternalServerError.Message)
+	}
+
+	var software []models.Software
+
+	stmt := c.db.Preload("URL").Preload("Aliases").Scopes(catalogScope(catalog))
+
+	stmt, err = general.Clauses(ctx, stmt, "")
+	if err != nil {
+		return common.Error(fiber.StatusUnprocessableEntity, "can't get Software", err.Error())
+	}
+
+	if all := ctx.QueryBool("all", false); !all {
+		stmt = stmt.Scopes(models.Active)
+	}
+
+	paginator := general.NewPaginator(ctx)
+
+	result, cursor, err := paginator.Paginate(stmt, &software)
+	if err != nil {
+		return common.Error(
+			fiber.StatusUnprocessableEntity,
+			"can't get Software",
+			"wrong cursor format in page[after] or page[before]",
+		)
+	}
+
+	if result.Error != nil {
+		return common.Error(
+			fiber.StatusInternalServerError,
+			"can't get Software",
+			fiber.ErrInternalServerError.Message,
+		)
+	}
+
+	return ctx.JSON(fiber.Map{"data": &software, "links": general.PaginationLinks(cursor)})
+}
+
+// resolveCatalog looks up a catalog by id or alternativeId.
+// If id is rootCatalogID and no catalog with that id exists, it returns nil
+// (meaning: filter by catalog_id IS NULL).
+func (c *Catalog) resolveCatalog(rawID string) (*models.Catalog, error) {
+	catalogID, err := url.PathUnescape(rawID)
+	if err != nil {
+		catalogID = rawID
+	}
+
+	var catalog models.Catalog
+
+	dbErr := c.db.First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error
+	if dbErr == nil {
+		return &catalog, nil
+	}
+
+	if errors.Is(dbErr, gorm.ErrRecordNotFound) && catalogID == rootCatalogID {
+		return nil, nil //nolint:nilnil
+	}
+
+	return nil, dbErr
+}

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -24,7 +24,10 @@ type PublisherInterface interface {
 	DeletePublisher(ctx *fiber.Ctx) error
 }
 
-const alreadyExists = "already exists"
+const (
+	alreadyExists        = "already exists"
+	contentTypeJSONPatch = "application/json-patch+json"
+)
 
 type Publisher struct {
 	db *gorm.DB
@@ -109,6 +112,7 @@ func (p *Publisher) PostPublisher(ctx *fiber.Ctx) error {
 
 	publisher := &models.Publisher{
 		ID:            utils.UUIDv4(),
+		CatalogID:     request.CatalogID,
 		Description:   request.Description,
 		Email:         normalizedEmail,
 		Active:        request.Active,
@@ -180,7 +184,7 @@ func (p *Publisher) PatchPublisher(ctx *fiber.Ctx) error { //nolint:cyclop,funle
 	var updatedJSON []byte
 
 	switch ctx.Get(fiber.HeaderContentType) {
-	case "application/json-patch+json":
+	case contentTypeJSONPatch:
 		patch, err := jsonpatch.DecodePatch(ctx.Body())
 		if err != nil {
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
@@ -235,6 +239,7 @@ func (p *Publisher) PatchPublisher(ctx *fiber.Ctx) error { //nolint:cyclop,funle
 			return err
 		}
 
+		publisher.CatalogID = updatedPublisher.CatalogID
 		publisher.Description = updatedPublisher.Description
 		publisher.Email = updatedPublisher.Email
 		publisher.Active = updatedPublisher.Active

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -161,6 +161,7 @@ func (p *Software) PostSoftware(ctx *fiber.Ctx) error {
 		URL:           url,
 		SoftwareURLID: url.ID,
 
+		CatalogID:     softwareReq.CatalogID,
 		Aliases:       aliases,
 		PubliccodeYml: softwareReq.PubliccodeYml,
 		Active:        softwareReq.Active,
@@ -196,7 +197,7 @@ func (p *Software) PatchSoftware(ctx *fiber.Ctx) error { //nolint:funlen,cyclop
 	var updatedJSON []byte
 
 	switch ctx.Get(fiber.HeaderContentType) {
-	case "application/json-patch+json":
+	case contentTypeJSONPatch:
 		patch, err := jsonpatch.DecodePatch(ctx.Body())
 		if err != nil {
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -32,8 +32,26 @@ type Log struct {
 	Entity     string  `json:"entity,omitempty" gorm:"->;type:text GENERATED ALWAYS AS (CASE WHEN entity_id IS NULL THEN NULL ELSE ('/' || entity_type || '/' || entity_id) END) STORED;default:(-);"` //nolint:lll
 }
 
+type Catalog struct {
+	ID            string    `json:"id" gorm:"primaryKey"`
+	Name          string    `json:"name" gorm:"not null"`
+	AlternativeID *string   `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
+	Active        *bool     `json:"active" gorm:"default:true;not null"`
+	CreatedAt     time.Time `json:"createdAt" gorm:"index"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+func (Catalog) TableName() string {
+	return "catalogs"
+}
+
+func (c Catalog) UUID() string {
+	return c.ID
+}
+
 type Publisher struct {
 	ID            string        `json:"id" gorm:"primaryKey"`
+	CatalogID     *string       `json:"catalogId,omitempty" gorm:"index"`
 	Email         *string       `json:"email,omitempty"`
 	Description   string        `json:"description" gorm:"uniqueIndex;not null"`
 	CodeHosting   []CodeHosting `json:"codeHosting" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
@@ -65,7 +83,8 @@ type CodeHosting struct {
 }
 
 type Software struct {
-	ID string `json:"id" gorm:"primarykey"`
+	ID        string  `json:"id" gorm:"primarykey"`
+	CatalogID *string `json:"catalogId,omitempty" gorm:"index"`
 
 	// This needs to be explicitly declared, otherwise GORM won't create
 	// the foreign key and will be confused about the double relationship

--- a/main.go
+++ b/main.go
@@ -122,7 +122,8 @@ func Setup() *fiber.App {
 	return app
 }
 
-func setupHandlers(app *fiber.App, gormDB *gorm.DB) {
+func setupHandlers(app *fiber.App, gormDB *gorm.DB) { //nolint:funlen
+	catalogHandler := handlers.NewCatalog(gormDB)
 	publisherHandler := handlers.NewPublisher(gormDB)
 	softwareHandler := handlers.NewSoftware(gormDB)
 	statusHandler := handlers.NewStatus(gormDB)
@@ -132,6 +133,14 @@ func setupHandlers(app *fiber.App, gormDB *gorm.DB) {
 
 	//nolint:varnamelen
 	v1 := app.Group("/v1")
+
+	v1.Get("/catalogs", catalogHandler.GetCatalogs)
+	v1.Post("/catalogs", catalogHandler.PostCatalog)
+	v1.Get("/catalogs/:id", catalogHandler.GetCatalog)
+	v1.Patch("/catalogs/:id", catalogHandler.PatchCatalog)
+	v1.Delete("/catalogs/:id", catalogHandler.DeleteCatalog)
+	v1.Get("/catalogs/:id/publishers", catalogHandler.GetCatalogPublishers)
+	v1.Get("/catalogs/:id/software", catalogHandler.GetCatalogSoftware)
 
 	v1.Get("/publishers/webhooks", publisherWebhookHandler.GetResourceWebhooks)
 	v1.Post("/publishers/webhooks", publisherWebhookHandler.PostResourceWebhook)

--- a/publishers_test.go
+++ b/publishers_test.go
@@ -34,7 +34,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 				assertUUID(t, firstPub["id"])
 				assertTimestamps(t, firstPub)
-				assertOnlyKeys(t, firstPub, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active")
+				assertOnlyKeys(t, firstPub, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active", "catalogId")
 			},
 		},
 		{
@@ -57,7 +57,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 				assertUUID(t, firstPub["id"])
 				assertTimestamps(t, firstPub)
-				assertOnlyKeys(t, firstPub, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active")
+				assertOnlyKeys(t, firstPub, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active", "catalogId")
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 				assertUUID(t, firstPub["id"])
 				assertTimestamps(t, firstPub)
-				assertOnlyKeys(t, firstPub, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active")
+				assertOnlyKeys(t, firstPub, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active", "catalogId")
 			},
 		},
 		{
@@ -231,7 +231,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active", "catalogId")
 			},
 		},
 		{
@@ -244,7 +244,7 @@ func TestPublishersEndpoints(t *testing.T) {
 				assert.Equal(t, "alternative-id-12345", response["alternativeId"])
 
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active", "alternativeId")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "codeHosting", "email", "description", "active", "catalogId", "alternativeId")
 			},
 		},
 

--- a/software_test.go
+++ b/software_test.go
@@ -42,7 +42,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, true, firstSoftware["active"])
 
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, true, firstSoftware["active"])
 
 				assertTimestamps(t, firstSoftware)
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, firstSoftware["id"])
 				assertTimestamps(t, firstSoftware)
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, "2014-05-01T00:00:00Z", firstSoftware["createdAt"])
 				assert.Equal(t, "2014-05-01T00:00:00Z", firstSoftware["updatedAt"])
 
-				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, firstSoftware, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 			},
 		},
 		{
@@ -307,7 +307,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 			},
 		},
 		{
@@ -325,7 +325,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 			},
 		},
 
@@ -351,7 +351,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, true, response["active"])
 
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 
 			},
 		},
@@ -379,7 +379,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 
 			},
 		},
@@ -423,7 +423,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assertUUID(t, response["id"])
 				assertTimestamps(t, response)
-				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality")
+				assertOnlyKeys(t, response, "id", "createdAt", "updatedAt", "url", "aliases", "publiccodeYml", "active", "vitality", "catalogId")
 
 			},
 		},

--- a/test/testdata/fixtures/catalogs.yml
+++ b/test/testdata/fixtures/catalogs.yml
@@ -1,0 +1,13 @@
+---
+- id: a8e5e6d7-0b1c-4f2a-8e3d-9c4b5a6f7e8d
+  name: Italian Catalog
+  alternative_id: italia
+  active: true
+  created_at: '2020-01-01T00:00:00+00:00'
+  updated_at: '2020-01-01T00:00:00+00:00'
+- id: b9f6f7e8-1c2d-4f3b-9f4e-0d5c6b7a8f9e
+  name: Swiss Catalog
+  alternative_id: swiss
+  active: true
+  created_at: '2020-06-01T00:00:00+00:00'
+  updated_at: '2020-06-01T00:00:00+00:00'

--- a/test/testdata/fixtures/publishers.yml
+++ b/test/testdata/fixtures/publishers.yml
@@ -2,11 +2,13 @@
 - id: 2ded32eb-c45e-4167-9166-a44e18b8adde
   description: Publisher description 1
   email: foobar@1.example.org
+  catalog_id: a8e5e6d7-0b1c-4f2a-8e3d-9c4b5a6f7e8d
   created_at: '2018-05-01T00:00:00+00:00'
   updated_at: '2018-05-01T00:00:00+00:00'
 - id: 47807e0c-0613-4aea-9917-5455cc6eddad
   description: Publisher description 2
   email: foobar@2.example.org
+  catalog_id: b9f6f7e8-1c2d-4f3b-9f4e-0d5c6b7a8f9e
   created_at: '2018-05-16T00:00:00+00:00'
   updated_at: '2018-05-16T00:00:00+00:00'
 - id: d6ddc11a-ff85-4f0f-bb87-df38b2a9b394

--- a/test/testdata/fixtures/software.yml
+++ b/test/testdata/fixtures/software.yml
@@ -2,12 +2,14 @@
 - id: c353756e-8597-4e46-a99b-7da2e141603b
   publiccode_yml: "-"
   software_url_id: beeadd3e-11bb-4313-99bb-94cd51836926
+  catalog_id: a8e5e6d7-0b1c-4f2a-8e3d-9c4b5a6f7e8d
   created_at: '2014-05-01T00:00:00+00:00'
   updated_at: '2014-05-01T00:00:00+00:00'
 - id: 9f135268-a37e-4ead-96ec-e4a24bb9344a
   publiccode_yml: "-"
   software_url_id: f22d408f-93a5-411c-9c35-99039514afc4
   vitality: "90,85,90,90"
+  catalog_id: b9f6f7e8-1c2d-4f3b-9f4e-0d5c6b7a8f9e
   created_at: '2014-05-16T00:00:00+00:00'
   updated_at: '2014-05-16T00:00:00+00:00'
 - id: 18348f13-1076-4a1e-b204-ed541b824d64


### PR DESCRIPTION
Adds /v1/catalogs (CRUD) to group software and publishers by origin (fe. could be "developers.italia.it", "opencode.de", "spain", etc).

Each software and publisher gets an optional catalogId FK. If absent, they belong to the root (implicit) catalog.

Fix #332.