### PR TITLE
feat: add sources to catalogs

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -42,7 +42,7 @@ func TestCatalogEndpoints(t *testing.T) {
 				first := data[0]
 				assertUUID(t, first["id"])
 				assertTimestamps(t, first)
-				assertOnlyKeys(t, first, "id", "name", "alternativeId", "active", "createdAt", "updatedAt")
+				assertOnlyKeys(t, first, "id", "name", "alternativeId", "active", "sources", "createdAt", "updatedAt")
 			},
 		},
 
@@ -56,7 +56,7 @@ func TestCatalogEndpoints(t *testing.T) {
 				assert.Equal(t, italiaID, response["id"])
 				assert.Equal(t, "Italian Catalog", response["name"])
 				assert.Equal(t, "italia", response["alternativeId"])
-				assertOnlyKeys(t, response, "id", "name", "alternativeId", "active", "createdAt", "updatedAt")
+				assertOnlyKeys(t, response, "id", "name", "alternativeId", "active", "sources", "createdAt", "updatedAt")
 			},
 		},
 		{
@@ -88,7 +88,7 @@ func TestCatalogEndpoints(t *testing.T) {
 		{
 			description: "POST catalog",
 			query:       "POST /v1/catalogs",
-			body:        `{"name": "New Catalog"}`,
+			body:        `{"name": "New Catalog", "sources": [{"url": "https://github.com/example/new-catalog"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -98,13 +98,13 @@ func TestCatalogEndpoints(t *testing.T) {
 			validateFunc: func(t *testing.T, response map[string]interface{}) {
 				assertUUID(t, response["id"])
 				assert.Equal(t, "New Catalog", response["name"])
-				assertOnlyKeys(t, response, "id", "name", "active", "createdAt", "updatedAt")
+				assertOnlyKeys(t, response, "id", "name", "active", "sources", "createdAt", "updatedAt")
 			},
 		},
 		{
 			description: "POST catalog with alternativeId",
 			query:       "POST /v1/catalogs",
-			body:        `{"name": "Another Catalog", "alternativeId": "another"}`,
+			body:        `{"name": "Another Catalog", "alternativeId": "another", "sources": [{"url": "https://github.com/example/another"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -118,7 +118,7 @@ func TestCatalogEndpoints(t *testing.T) {
 		{
 			description: "POST catalog duplicate alternativeId",
 			query:       "POST /v1/catalogs",
-			body:        `{"name": "Dup", "alternativeId": "italia"}`,
+			body:        `{"name": "Dup", "alternativeId": "italia", "sources": [{"url": "https://github.com/example/dup"}]}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},
@@ -137,7 +137,7 @@ func TestCatalogEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Catalog","detail":"invalid format: name is required","status":422,"validationErrors":[{"field":"name","rule":"required","value":""}]}`,
+			expectedBody:        `{"title":"can't create Catalog","detail":"invalid format: name is required, sources is required","status":422,"validationErrors":[{"field":"name","rule":"required","value":""},{"field":"sources","rule":"required","value":""}]}`,
 		},
 		{
 			description:         "POST catalog - no token",
@@ -613,11 +613,10 @@ func TestCatalogSoftwareDBChecks(t *testing.T) {
 }
 
 func TestCatalogDeleteDBChecks(t *testing.T) {
-	t.Run("DELETE catalog removes it from DB when empty", func(t *testing.T) {
+	t.Run("DELETE catalog removes it and its sources from DB", func(t *testing.T) {
 		loadFixtures(t)
 
-		// Create an empty catalog to delete
-		body := `{"name": "To Delete"}`
+		body := `{"name": "To Delete", "sources": [{"url": "https://github.com/example/to-delete"}]}`
 		req, err := http.NewRequest("POST", "/v1/catalogs", strings.NewReader(body))
 		require.NoError(t, err)
 		req.Header = map[string][]string{
@@ -642,5 +641,68 @@ func TestCatalogDeleteDBChecks(t *testing.T) {
 		assert.Equal(t, 204, res.StatusCode)
 
 		assert.Equal(t, 0, dbCount(t, "catalogs", "id", catalogID))
+		assert.Equal(t, 0, dbCount(t, "catalog_sources", "catalog_id", catalogID))
+	})
+}
+
+func TestCatalogSourcesDBChecks(t *testing.T) {
+	t.Run("POST stores driver when provided", func(t *testing.T) {
+		loadFixtures(t)
+
+		body := `{"name":"With Driver","sources":[{"url":"https://code.example.org/repo","driver":"custom"}]}`
+		req, err := http.NewRequest("POST", "/v1/catalogs", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		var created map[string]interface{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&created))
+		catalogID := created["id"].(string)
+
+		assert.Equal(t, "custom", dbValue(t, "catalog_sources", "driver", "catalog_id", catalogID))
+	})
+
+	t.Run("POST accepts source without driver", func(t *testing.T) {
+		loadFixtures(t)
+
+		body := `{"name":"No Driver","sources":[{"url":"https://code.example.org/repo"}]}`
+		req, err := http.NewRequest("POST", "/v1/catalogs", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+	})
+
+	t.Run("PATCH with sources replaces them", func(t *testing.T) {
+		loadFixtures(t)
+
+		const sourceURL = "https://gitlab.com/example/replaced"
+
+		body := fmt.Sprintf(`{"sources":[{"url":"%s","driver":"gitlab"}]}`, sourceURL)
+		req, err := http.NewRequest("PATCH", "/v1/catalogs/"+italiaID, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		require.Equal(t, 200, res.StatusCode)
+
+		assert.Equal(t, 1, dbCount(t, "catalog_sources", "catalog_id", italiaID))
+		assert.Equal(t, sourceURL, dbValue(t, "catalog_sources", "url", "catalog_id", italiaID))
+		assert.Equal(t, "gitlab", dbValue(t, "catalog_sources", "driver", "catalog_id", italiaID))
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/ansrivas/fiberprometheus/v2 v2.17.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/jackc/pgx/v5 v5.9.1
+	github.com/spf13/cobra v1.10.2
 	github.com/valyala/fasthttp v1.69.0
 )
 
@@ -68,7 +69,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	go.opentelemetry.io/otel v1.40.0 // indirect

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -17,16 +17,24 @@ func NormalizeURL(rawURL string) string {
 	return normalized
 }
 
+type SourceInput struct {
+	Driver *string  `json:"driver" validate:"omitempty,min=1,max=64"`
+	URL    string   `json:"url" validate:"required,url"`
+	Args   []string `json:"args" validate:"omitempty,dive,min=1"`
+}
+
 type CatalogPost struct {
-	Name          string  `json:"name" validate:"required,min=1,max=255"`
-	AlternativeID *string `json:"alternativeId" validate:"omitempty,min=1,max=255"`
-	Active        *bool   `json:"active"`
+	Name          string        `json:"name" validate:"required,min=1,max=255"`
+	AlternativeID *string       `json:"alternativeId" validate:"omitempty,min=1,max=255"`
+	Active        *bool         `json:"active"`
+	Sources       []SourceInput `json:"sources" validate:"required,gt=0,dive"`
 }
 
 type CatalogPatch struct {
-	Name          *string `json:"name" validate:"omitempty,min=1,max=255"`
-	AlternativeID *string `json:"alternativeId" validate:"omitempty,max=255"`
-	Active        *bool   `json:"active"`
+	Name          *string        `json:"name" validate:"omitempty,min=1,max=255"`
+	AlternativeID *string        `json:"alternativeId" validate:"omitempty,max=255"`
+	Active        *bool          `json:"active"`
+	Sources       *[]SourceInput `json:"sources" validate:"omitempty,gt=0,dive"`
 }
 
 type PublisherPost struct {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -39,6 +39,7 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 
 	if err = database.AutoMigrate(
 		&models.Catalog{},
+		&models.CatalogSource{},
 		&models.Publisher{},
 		&models.Event{},
 		&models.CodeHosting{},

--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -58,7 +58,7 @@ func catalogScope(catalog *models.Catalog) func(*gorm.DB) *gorm.DB {
 func (c *Catalog) GetCatalogs(ctx *fiber.Ctx) error {
 	var catalogs []models.Catalog
 
-	stmt, err := general.Clauses(ctx, c.db, "")
+	stmt, err := general.Clauses(ctx, c.db.Preload("Sources"), "")
 	if err != nil {
 		return common.Error(fiber.StatusUnprocessableEntity, "can't get Catalogs", err.Error())
 	}
@@ -93,7 +93,7 @@ func (c *Catalog) GetCatalogs(ctx *fiber.Ctx) error {
 func (c *Catalog) GetCatalog(ctx *fiber.Ctx) error {
 	id, _ := url.PathUnescape(ctx.Params("id"))
 
-	catalog, err := c.resolveCatalog(id)
+	catalog, err := c.resolveCatalog(id, "Sources")
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return common.Error(fiber.StatusNotFound, "can't get Catalog", "Catalog was not found")
@@ -120,11 +120,14 @@ func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
 		return err //nolint:wrapcheck
 	}
 
+	sources := buildSources(request.Sources)
+
 	catalog := &models.Catalog{
 		ID:            utils.UUIDv4(),
 		Name:          request.Name,
 		AlternativeID: request.AlternativeID,
 		Active:        request.Active,
+		Sources:       sources,
 	}
 
 	if err := c.db.Create(catalog).Error; err != nil {
@@ -144,7 +147,7 @@ func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
 }
 
 // PatchCatalog updates the catalog with the given id.
-func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
+func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop,funlen
 	const errMsg = "can't update Catalog"
 
 	catalogID, _ := url.PathUnescape(ctx.Params("id"))
@@ -155,7 +158,8 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 
 	catalog := models.Catalog{}
 
-	if err := c.db.First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error; err != nil {
+	err := c.db.Preload("Sources").First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error
+	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
 		}
@@ -203,7 +207,35 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 
 	updatedCatalog.ID = catalog.ID
 
-	if err := c.db.Updates(&updatedCatalog).Error; err != nil {
+	sourcesInput := make([]common.SourceInput, 0, len(updatedCatalog.Sources))
+	for _, src := range updatedCatalog.Sources {
+		sourcesInput = append(sourcesInput, common.SourceInput{
+			URL:    src.URL,
+			Driver: src.Driver,
+			Args:   src.Args,
+		})
+	}
+
+	if len(sourcesInput) == 0 {
+		return common.Error(fiber.StatusUnprocessableEntity, errMsg, "sources must not be empty")
+	}
+
+	if err := c.db.Transaction(func(tran *gorm.DB) error {
+		sources, err := syncSources(tran, catalog, sourcesInput)
+		if err != nil {
+			return err
+		}
+
+		updatedCatalog.Sources = nil
+
+		if err := tran.Updates(&updatedCatalog).Error; err != nil {
+			return err
+		}
+
+		updatedCatalog.Sources = sources
+
+		return nil
+	}); err != nil {
 		if field := common.DuplicateField(err); field != nil {
 			detail := alreadyExists
 			if *field != "" {
@@ -221,7 +253,7 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 
 // DeleteCatalog deletes the catalog with the given id.
 // Returns 409 if the catalog still has associated publishers or software.
-func (c *Catalog) DeleteCatalog(ctx *fiber.Ctx) error {
+func (c *Catalog) DeleteCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 	const errMsg = "can't delete Catalog"
 
 	catalogID, _ := url.PathUnescape(ctx.Params("id"))
@@ -258,6 +290,10 @@ func (c *Catalog) DeleteCatalog(ctx *fiber.Ctx) error {
 			conflictErr = common.Error(fiber.StatusConflict, errMsg, "Catalog still has associated publishers or software")
 
 			return nil
+		}
+
+		if err := tran.Where("catalog_id = ?", catalog.ID).Delete(&models.CatalogSource{}).Error; err != nil {
+			return err
 		}
 
 		return tran.Where("id = ?", catalog.ID).Delete(&models.Catalog{}).Error
@@ -754,10 +790,116 @@ func (c *Catalog) GetCatalogSoftware(ctx *fiber.Ctx) error {
 	return ctx.JSON(fiber.Map{"data": &software, "links": general.PaginationLinks(cursor)})
 }
 
+// buildSources converts SourceInput slice to CatalogSource models.
+func buildSources(inputs []common.SourceInput) []models.CatalogSource {
+	sources := make([]models.CatalogSource, 0, len(inputs))
+
+	for _, inp := range inputs {
+		sources = append(sources, models.CatalogSource{
+			ID:     utils.UUIDv4(),
+			Driver: inp.Driver,
+			URL:    common.NormalizeURL(inp.URL),
+			Args:   inp.Args,
+		})
+	}
+
+	return sources
+}
+
+// syncSources brings the catalog_sources table in line with the desired state.
+// Sources are matched by URL; removed if absent, added if new.
+func syncSources( //nolint:cyclop,funlen
+	gormdb *gorm.DB,
+	catalog models.Catalog,
+	desired []common.SourceInput,
+) ([]models.CatalogSource, error) {
+	toRemove := []string{}
+	toAdd := []models.CatalogSource{}
+	toUpdate := []models.CatalogSource{}
+
+	urlMap := map[string]models.CatalogSource{}
+	for _, src := range catalog.Sources {
+		urlMap[src.URL] = src
+	}
+
+	desiredSet := map[string]common.SourceInput{}
+	for _, inp := range desired {
+		desiredSet[common.NormalizeURL(inp.URL)] = inp
+	}
+
+	for srcURL, src := range urlMap {
+		if _, ok := desiredSet[srcURL]; !ok {
+			toRemove = append(toRemove, src.ID)
+
+			delete(urlMap, srcURL)
+		}
+	}
+
+	for srcURL, inp := range desiredSet {
+		if existing, ok := urlMap[srcURL]; ok {
+			changed := false
+
+			if inp.Driver != nil && (existing.Driver == nil || *existing.Driver != *inp.Driver) {
+				existing.Driver = inp.Driver
+				changed = true
+			}
+
+			if inp.Args != nil {
+				existing.Args = inp.Args
+				changed = true
+			}
+
+			if changed {
+				toUpdate = append(toUpdate, existing)
+				urlMap[srcURL] = existing
+			}
+		} else {
+			src := models.CatalogSource{
+				ID:        utils.UUIDv4(),
+				Driver:    inp.Driver,
+				URL:       common.NormalizeURL(srcURL),
+				Args:      inp.Args,
+				CatalogID: catalog.ID,
+			}
+			toAdd = append(toAdd, src)
+			urlMap[srcURL] = src
+		}
+	}
+
+	if len(toRemove) > 0 {
+		if err := gormdb.Delete(&models.CatalogSource{}, toRemove).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	if len(toAdd) > 0 {
+		if err := gormdb.Create(toAdd).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	for _, src := range toUpdate {
+		if err := gormdb.Model(&src).Updates(map[string]any{
+			"driver": src.Driver,
+			"args":   src.Args,
+		}).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	ret := make([]models.CatalogSource, 0, len(urlMap))
+	for _, src := range urlMap {
+		ret = append(ret, src)
+	}
+
+	return ret, nil
+}
+
 // resolveCatalog looks up a catalog by id or alternativeId.
 // If id is rootCatalogID and no catalog with that id exists, it returns nil
 // (meaning: filter by catalog_id IS NULL).
-func (c *Catalog) resolveCatalog(rawID string) (*models.Catalog, error) {
+// Optional preloads (e.g. "Sources") are applied to the query.
+func (c *Catalog) resolveCatalog(rawID string, preloads ...string) (*models.Catalog, error) {
 	catalogID, err := url.PathUnescape(rawID)
 	if err != nil {
 		catalogID = rawID
@@ -765,7 +907,12 @@ func (c *Catalog) resolveCatalog(rawID string) (*models.Catalog, error) {
 
 	var catalog models.Catalog
 
-	dbErr := c.db.First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error
+	stmt := c.db
+	for _, p := range preloads {
+		stmt = stmt.Preload(p)
+	}
+
+	dbErr := stmt.First(&catalog, "id = ? OR alternative_id = ?", catalogID, catalogID).Error
 	if dbErr == nil {
 		return &catalog, nil
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -33,12 +33,27 @@ type Log struct {
 }
 
 type Catalog struct {
-	ID            string    `json:"id" gorm:"primaryKey"`
-	Name          string    `json:"name" gorm:"not null"`
-	AlternativeID *string   `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
-	Active        *bool     `json:"active" gorm:"default:true;not null"`
-	CreatedAt     time.Time `json:"createdAt" gorm:"index"`
-	UpdatedAt     time.Time `json:"updatedAt"`
+	ID            string          `json:"id" gorm:"primaryKey"`
+	Name          string          `json:"name" gorm:"not null"`
+	AlternativeID *string         `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
+	Active        *bool           `json:"active" gorm:"default:true;not null"`
+	Sources       []CatalogSource `json:"sources" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	CreatedAt     time.Time       `json:"createdAt" gorm:"index"`
+	UpdatedAt     time.Time       `json:"updatedAt"`
+}
+
+type CatalogSource struct {
+	ID        string    `json:"-" gorm:"primaryKey"`
+	Driver    *string   `json:"driver,omitempty" gorm:"index"`
+	URL       string    `json:"url" gorm:"not null"`
+	Args      []string  `json:"args,omitempty" gorm:"serializer:json"`
+	CatalogID string    `json:"-" gorm:"not null;index"`
+	CreatedAt time.Time `json:"-" gorm:"index"`
+	UpdatedAt time.Time `json:"-"`
+}
+
+func (CatalogSource) TableName() string {
+	return "catalog_sources"
 }
 
 func (Catalog) TableName() string {

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2023,6 +2023,14 @@ components:
         active:
           type: boolean
           default: true
+        sources:
+          type: array
+          minItems: 1
+          description: >
+            Data sources for this catalog. At least one is
+            required on creation.
+          items:
+            $ref: '#/components/schemas/CatalogSource'
         createdAt:
           type: string
           format: date-time
@@ -2038,8 +2046,34 @@ components:
       required:
         - id
         - name
+        - sources
         - createdAt
         - updatedAt
+    CatalogSource:
+      title: CatalogSource
+      type: object
+      additionalProperties: false
+      properties:
+        driver:
+          type: string
+          maxLength: 64
+          description: >
+            Driver used to crawl this source.
+          example: 'github'
+        url:
+          type: string
+          format: uri
+          example: 'https://github.com/org'
+        args:
+          type: array
+          description: >
+            Optional arguments for the driver (e.g. a JSON
+            configuration file URL).
+          items:
+            type: string
+            minLength: 1
+      required:
+        - url
     Publisher:
       title: Publisher
       type: object

--- a/test/testdata/fixtures/catalog_sources.yml
+++ b/test/testdata/fixtures/catalog_sources.yml
@@ -1,0 +1,13 @@
+---
+- id: aaa11111-1111-1111-1111-111111111111
+  driver: github
+  url: https://github.com/example/italia-catalog
+  catalog_id: a8e5e6d7-0b1c-4f2a-8e3d-9c4b5a6f7e8d
+  created_at: '2020-01-01T00:00:00+00:00'
+  updated_at: '2020-01-01T00:00:00+00:00'
+- id: bbb22222-2222-2222-2222-222222222222
+  driver: github
+  url: https://github.com/example/swiss-catalog
+  catalog_id: b9f6f7e8-1c2d-4f3b-9f4e-0d5c6b7a8f9e
+  created_at: '2020-06-01T00:00:00+00:00'
+  updated_at: '2020-06-01T00:00:00+00:00'


### PR DESCRIPTION
Each catalog now requires at least one source. A source has a URL, an optional driver and optional args that will be used to turn the source in a list of repos to scan.

Example:

    POST /v1/catalogs
    {"name": "My Catalog", "sources": [{"url": "https://github.com/org", "driver": "github"}]}