### PR TITLE
feat: add publishersNamespace to catalogs

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -24,17 +24,19 @@ type SourceInput struct {
 }
 
 type CatalogPost struct {
-	Name          string        `json:"name" validate:"required,min=1,max=255"`
-	AlternativeID *string       `json:"alternativeId" validate:"omitempty,min=1,max=255"`
-	Active        *bool         `json:"active"`
-	Sources       []SourceInput `json:"sources" validate:"required,gt=0,dive"`
+	Name                string        `json:"name" validate:"required,min=1,max=255"`
+	AlternativeID       *string       `json:"alternativeId" validate:"omitempty,min=1,max=255"`
+	Active              *bool         `json:"active"`
+	PublishersNamespace *string       `json:"publishersNamespace" validate:"omitempty,max=255"`
+	Sources             []SourceInput `json:"sources" validate:"required,gt=0,dive"`
 }
 
 type CatalogPatch struct {
-	Name          *string        `json:"name" validate:"omitempty,min=1,max=255"`
-	AlternativeID *string        `json:"alternativeId" validate:"omitempty,max=255"`
-	Active        *bool          `json:"active"`
-	Sources       *[]SourceInput `json:"sources" validate:"omitempty,gt=0,dive"`
+	Name                *string        `json:"name" validate:"omitempty,min=1,max=255"`
+	AlternativeID       *string        `json:"alternativeId" validate:"omitempty,max=255"`
+	Active              *bool          `json:"active"`
+	PublishersNamespace *string        `json:"publishersNamespace" validate:"omitempty,max=255"`
+	Sources             *[]SourceInput `json:"sources" validate:"omitempty,gt=0,dive"`
 }
 
 type PublisherPost struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -33,13 +33,14 @@ type Log struct {
 }
 
 type Catalog struct {
-	ID            string          `json:"id" gorm:"primaryKey"`
-	Name          string          `json:"name" gorm:"not null"`
-	AlternativeID *string         `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
-	Active        *bool           `json:"active" gorm:"default:true;not null"`
-	Sources       []CatalogSource `json:"sources" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	CreatedAt     time.Time       `json:"createdAt" gorm:"index"`
-	UpdatedAt     time.Time       `json:"updatedAt"`
+	ID                  string          `json:"id" gorm:"primaryKey"`
+	Name                string          `json:"name" gorm:"not null"`
+	AlternativeID       *string         `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
+	Active              *bool           `json:"active" gorm:"default:true;not null"`
+	PublishersNamespace *string         `json:"publishersNamespace,omitempty"`
+	Sources             []CatalogSource `json:"sources" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	CreatedAt           time.Time       `json:"createdAt" gorm:"index"`
+	UpdatedAt           time.Time       `json:"updatedAt"`
 }
 
 type CatalogSource struct {

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2023,6 +2023,15 @@ components:
         active:
           type: boolean
           default: true
+        publishersNamespace:
+          type: string
+          maxLength: 255
+          description: >
+            Namespace prefix for publisher organisation
+            validation. When set, consumers can check that
+            each publiccode.yml organisation field equals
+            this prefix + the publisher alternativeId.
+          example: 'urn:x-italian-pa:'
         sources:
           type: array
           minItems: 1


### PR DESCRIPTION
Optional string field on Catalog. When set, consumers can use it to validate that each publisher's organisation matches the namespace prefix + publisher alternativeId.