### PR TITLE
fix: add url query filter to GetCatalogSoftware

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -541,6 +541,29 @@ func TestCatalogEndpoints(t *testing.T) {
 			},
 		},
 		{
+			description:         "GET catalog software filtered by url",
+			query:               "GET /v1/catalogs/" + italiaID + "/software?url=https://1-a.example.org/code/repo",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 1, len(data))
+				assert.Equal(t, italiaSoftwareID, data[0]["id"])
+			},
+		},
+		{
+			description:         "GET catalog software filtered by url - not found",
+			query:               "GET /v1/catalogs/" + italiaID + "/software?url=https://no.such.url.example.org",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 0, len(data))
+			},
+		},
+		{
 			description:         "GET root catalog software (∅)",
 			query:               "GET /v1/catalogs/%E2%88%85/software",
 			expectedCode:        200,

--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -764,6 +764,22 @@ func (c *Catalog) GetCatalogSoftware(ctx *fiber.Ctx) error {
 		return common.Error(fiber.StatusUnprocessableEntity, "can't get Software", err.Error())
 	}
 
+	if urlFilter := common.NormalizeURL(ctx.Query("url", "")); urlFilter != "" {
+		var softwareURL models.SoftwareURL
+
+		if e := c.db.First(&softwareURL, "url = ?", urlFilter).Error; e != nil {
+			if errors.Is(e, gorm.ErrRecordNotFound) {
+				return ctx.JSON(fiber.Map{"data": []any{}, "links": general.PaginationLinks{}})
+			}
+
+			return common.Error(
+				fiber.StatusInternalServerError, "can't get Software", fiber.ErrInternalServerError.Message,
+			)
+		}
+
+		stmt = stmt.Where("id = ?", softwareURL.SoftwareID)
+	}
+
 	if all := ctx.QueryBool("all", false); !all {
 		stmt = stmt.Scopes(models.Active)
 	}


### PR DESCRIPTION
GET /catalogs/:id/software?url=... ignored the url parameter and returned all software in the catalog.

Also returns empty result early when the url is not found instead of relying on WHERE id = '' matching nothing.