### PR TITLE
fix: inactive software was returned when filtering by url

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -553,6 +553,17 @@ func TestCatalogEndpoints(t *testing.T) {
 			},
 		},
 		{
+			description:         "GET catalog software filtered by url excludes inactive",
+			query:               "GET /v1/catalogs/%E2%88%85/software?url=https://31-a.example.org/code/repo",
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 0, len(data))
+			},
+		},
+		{
 			description:         "GET catalog software filtered by url - not found",
 			query:               "GET /v1/catalogs/" + italiaID + "/software?url=https://no.such.url.example.org",
 			expectedCode:        200,

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -63,8 +63,11 @@ func (p *Software) GetAllSoftware(ctx *fiber.Ctx) error { //nolint:cyclop // mos
 	if url := common.NormalizeURL(ctx.Query("url", "")); url != "" {
 		var softwareURL models.SoftwareURL
 
-		err = p.db.First(&softwareURL, "url = ?", url).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		if err = p.db.First(&softwareURL, "url = ?", url).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ctx.JSON(fiber.Map{"data": []any{}, "links": general.PaginationLinks{}})
+			}
+
 			return common.Error(
 				fiber.StatusInternalServerError,
 				"can't get Software",
@@ -73,10 +76,10 @@ func (p *Software) GetAllSoftware(ctx *fiber.Ctx) error { //nolint:cyclop // mos
 		}
 
 		stmt = stmt.Where("id = ?", softwareURL.SoftwareID)
-	} else {
-		if all := ctx.QueryBool("all", false); !all {
-			stmt = stmt.Scopes(models.Active)
-		}
+	}
+
+	if all := ctx.QueryBool("all", false); !all {
+		stmt = stmt.Scopes(models.Active)
 	}
 
 	paginator := general.NewPaginator(ctx)

--- a/software_test.go
+++ b/software_test.go
@@ -159,6 +159,18 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 		},
 		{
+			description: "GET with url filter excludes inactive software",
+			query:       "GET /v1/software?url=https://31-a.example.org/code/repo",
+
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 0, len(data))
+			},
+		},
+		{
 			description: "GET with page[size] query param",
 			query:       "GET /v1/software?page[size]=2",
 


### PR DESCRIPTION
The active scope was skipped when the url query parameter was set, so inactive software showed up in results.