### PR TITLE
test: remove TODO blocks about Content-Type enforcement

### DIFF
--- a/logs_test.go
+++ b/logs_test.go
@@ -308,15 +308,6 @@ func TestLogsEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "POST /v1/logs with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// },
 	}
 
 	runTestCases(t, tests)

--- a/publishers_test.go
+++ b/publishers_test.go
@@ -789,17 +789,6 @@ func TestPublishersEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			expectedBody:        `{"title":"can't update Publisher","detail":"invalid or malformed JSON","status":400}`,
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "PATCH /v1/publishers with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// }
-
-
 		// JSON Patch
 		{
 			description: "PATCH a publisher with JSON Patch - replace description",
@@ -1090,15 +1079,6 @@ func TestPublishersEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "POST /v1/publishers/98a069f7-57b0-464d-b300-4b4b336297a0/webhooks with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// },
 	}
 
 	runTestCases(t, tests)

--- a/software_test.go
+++ b/software_test.go
@@ -557,16 +557,6 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "POST /v1/software with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// }
-
 		// PATCH /software/:id
 		{
 			description: "PATCH non-existing software",
@@ -1016,16 +1006,6 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "POST /v1/software with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// }
-
 		// DELETE /software/:id
 		{
 			description: "Delete non-existent software",
@@ -1240,16 +1220,6 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "POST /v1/logs with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// },
-
 		// GET /software/:id/webhooks
 		{
 			query: "GET /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
@@ -1426,15 +1396,6 @@ func TestSoftwareEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query: "POST /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks with no Content-Type",
-		// 	body:  "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// },
 	}
 
 	runTestCases(t, tests)

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -137,16 +137,6 @@ func TestWebhooksEndpoints(t *testing.T) {
 				assert.Equal(t, "invalid or malformed JSON", response["detail"])
 			},
 		},
-		// TODO: enforce this?
-		// {
-		// 	query:    "PATCH /v1/webhooks with no Content-Type",
-		// 	body:     "",
-		// 	headers: map[string][]string{
-		// 		"Authorization": {goodToken},
-		// 	},
-		// 	expectedCode:        404,
-		// },
-
 		// DELETE /webhooks/:id
 		{
 			description: "Delete non-existent webhook",


### PR DESCRIPTION
The commented-out TODO blocks tested that requests with no `Content-Type` header
would be rejected with a 415. We decided not to enforce this: the server already
returns a clear error when the body is not valid JSON, regardless of the header,
and enforcing the header adds friction for API clients without a real benefit.

Removes 8 dead-code blocks across `software_test.go`, `publishers_test.go`,
`logs_test.go`, and `webhooks_test.go`.