### PR TITLE
ci: replace spectral-action with npx spectral-cli

### DIFF
--- a/.github/workflows/spectral.yaml
+++ b/.github/workflows/spectral.yaml
@@ -8,18 +8,19 @@ on:
     paths:
       - '*.oas.yaml'
 
-permissions:
-  checks: write
+permissions: {}
 
 jobs:
   spectral:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: curl --fail -L https://github.com/italia/api-oas-checker-rules/releases/download/1.1/spectral-full.yml > .spectral.yml
 
       # Get additional module required by spectral-full
       - run: mkdir functions
       - run: curl --fail -L https://raw.githubusercontent.com/italia/api-oas-checker/f6f4e6e360b2ce9816dcca29396571dda1c6027d/security/functions/checkSecurity.js > functions/checkSecurity.js
 
-      - uses: stoplightio/spectral-action@v0.8.13
+      - run: npx --yes @stoplight/spectral-cli@6.15.1 lint --ruleset .spectral.yml '*.oas.yaml'


### PR DESCRIPTION
`spectral-action` exits with 0 on fork PRs even when lint violations are found — confirmed via a test PR (#351). The upstream bug (stoplightio/spectral-action#624) has been open since 2022 with no fix.

Running `@stoplight/spectral-cli` directly via `npx` propagates the exit code correctly regardless of the PR source, so the check will actually fail when the OAS has violations.

Also takes the opportunity to:
- drop `checks: write` (no longer needed — npx does not write check annotations)
- restrict job permissions to `contents: read`
- pin `actions/checkout` to commit SHA

Fix #67.