### PR TITLE
fix: remove duplicate description keys in OAS path params

### DIFF
--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -873,7 +873,6 @@ paths:
           example: 'example-catalog'
         name: catalogId
         in: path
-        description: The ID or alternativeId of the Catalog
         required: true
         description: >
           The catalog UUID or alternativeId.
@@ -956,7 +955,6 @@ paths:
           example: 'example-catalog'
         name: catalogId
         in: path
-        description: The ID or alternativeId of the Catalog
         required: true
         description: >
           The catalog UUID or alternativeId.
@@ -1067,7 +1065,6 @@ paths:
           example: 'example-catalog'
         name: catalogId
         in: path
-        description: The ID or alternativeId of the Catalog
         required: true
         description: >
           The catalog UUID or alternativeId.
@@ -1125,7 +1122,6 @@ paths:
           example: 'example-catalog'
         name: catalogId
         in: path
-        description: The ID or alternativeId of the Catalog
         required: true
         description: >
           The catalog UUID or alternativeId.
@@ -1233,7 +1229,6 @@ paths:
           example: 'example-catalog'
         name: catalogId
         in: path
-        description: The ID or alternativeId of the Catalog
         required: true
         description: >
           The catalog UUID or alternativeId.
@@ -1245,7 +1240,6 @@ paths:
           example: 'c353756e-8597-4e46-a99b-7da2e141603b'
         name: softwareId
         in: path
-        description: The ID of the Software
         required: true
         description: The software UUID
     patch:
@@ -1293,7 +1287,6 @@ paths:
           example: 'example-catalog'
         name: catalogId
         in: path
-        description: The ID or alternativeId of the Catalog
         required: true
         description: >
           The catalog UUID or alternativeId.


### PR DESCRIPTION
PR #353 introduced duplicate `description` mapping keys in path parameter objects that already had a `description` field defined below. YAML does not allow duplicate mapping keys; vacuum exits with code 2 and cannot parse the spec, breaking main branch CI.

Removes the 7 redundant shorter descriptions added to `catalogId` and `softwareId` path params.

Fix #353.