### PR TITLE
fix: use application/merge-patch+json for PATCH analysis endpoint

### DIFF
--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -436,7 +436,7 @@ func (p *Software) PatchSoftwareAnalysis(ctx *fiber.Ctx) error {
 	}
 
 	var incoming common.AnalysisData
-	if err := ctx.BodyParser(&incoming); err != nil {
+	if err := json.Unmarshal(ctx.Body(), &incoming); err != nil {
 		return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
 	}
 

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -318,7 +318,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          application/merge-patch+json:
             schema:
               $ref: '#/components/schemas/AnalysisData'
   '/software/{softwareId}/logs':
@@ -1961,6 +1961,7 @@ components:
         properties:
           v:
             type: integer
+            format: int32
             description: Schema version of this namespace.
             example: 1
           t:

--- a/software_test.go
+++ b/software_test.go
@@ -1485,7 +1485,7 @@ func TestSoftwareAnalysisEndpoints(t *testing.T) {
 			body:        `{"badges": {"v": 1, "score": 90}}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
-				"Content-Type":  {"application/json"},
+				"Content-Type":  {"application/merge-patch+json"},
 			},
 			expectedCode:        200,
 			expectedContentType: "application/json",
@@ -1503,7 +1503,7 @@ func TestSoftwareAnalysisEndpoints(t *testing.T) {
 			body:        `{"badges": {"score": 90}}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
-				"Content-Type":  {"application/json"},
+				"Content-Type":  {"application/merge-patch+json"},
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
@@ -1526,7 +1526,7 @@ func TestSoftwareAnalysisEndpoints(t *testing.T) {
 			body:        `{"badges": {"v": 1}}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
-				"Content-Type":  {"application/json"},
+				"Content-Type":  {"application/merge-patch+json"},
 			},
 			expectedCode:        404,
 			expectedContentType: "application/problem+json",
@@ -1550,7 +1550,7 @@ func TestSoftwareAnalysisDBChecks(t *testing.T) {
 		require.NoError(t, err)
 		req.Header = map[string][]string{
 			"Authorization": {goodToken},
-			"Content-Type":  {"application/json"},
+			"Content-Type":  {"application/merge-patch+json"},
 		}
 
 		res, err := app.Test(req, -1)


### PR DESCRIPTION
The `patch-media-type` rule in the Italian OAS checker ruleset forbids `application/json` as a PATCH content-type, per [RFC 6902 errata eid3169](https://www.rfc-editor.org/errata/eid3169). This violation was hidden because spectral-action crashed before reaching it.

`PATCH /software/{softwareId}/analysis` is a merge operation, so `application/merge-patch+json` is the correct media type. Fiber's `BodyParser` does not recognize `application/merge-patch+json`, so the handler switches to `json.Unmarshal(ctx.Body(), ...)` which parses the body directly.

Also removes the duplicate `description` mapping keys introduced in #353 (supersedes #355).