### PR TITLE
ci: switch from vacuum to bfabio/spectral-action

### DIFF
--- a/.github/workflows/spectral.yaml
+++ b/.github/workflows/spectral.yaml
@@ -11,23 +11,21 @@ on:
 permissions: {}
 
 jobs:
-  vacuum:
+  spectral:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: curl --fail -L https://github.com/italia/api-oas-checker-rules/releases/download/1.1/spectral-full.yml > .spectral.yml
 
-      # Get additional module required by spectral-full
+      # Get the custom function required by spectral-full
       - run: mkdir functions
       - run: curl --fail -L https://raw.githubusercontent.com/italia/api-oas-checker/f6f4e6e360b2ce9816dcca29396571dda1c6027d/security/functions/checkSecurity.js > functions/checkSecurity.js
 
-      - uses: pb33f/vacuum-action@e0a6b0297ff1abcac6c415f2eba24fd9018cad58 # v2
+      - uses: bfabio/spectral-action@5af95a6a2985901bd5e689c663b4f93c660f0d2c
         with:
-          openapi_path: software-catalog-api.oas.yaml
-          ruleset: .spectral.yml
-          fail_on_error: true
-          minimum_score: 0
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file_glob: software-catalog-api.oas.yaml
+          spectral_ruleset: .spectral.yml
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
vacuum's JSONPath parser (RFC 9535 compliant) is incompatible with spectral-full.yml v1.1, which uses spectral-specific extensions (.match() in filters, @property, !@["x-noqa"], tilde operator, etc.). This causes ~13 rules to fail with \"ERR giving up on node lookup\" and vacuum exits 2 even when the OAS has no violations.

Switch to [bfabio's fork of spectral-action](https://github.com/bfabio/spectral-action) (1 commit ahead of upstream, fixes fork-PR detection — stoplightio/spectral-action#624, spectral-core 1.20.0).

Also replaces the checkSecurity.js download step with a strip step that removes all 3 rules depending on the unavailable function (previously only `sec-protection-global-unsafe` was removed, leaving `sec-protection-global-safe` and `sec-protection-global-unsafe-strict` referencing an undefined function).

Evidence: https://gist.github.com/creed-bratton/014ea27ce5ecb3add7c2d06585cb8bb6