### PR TITLE
fix: address spectral warnings in OAS

### DIFF
--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -1962,6 +1962,8 @@ components:
           v:
             type: integer
             format: int32
+            minimum: 1
+            maximum: 999
             description: Schema version of this namespace.
             example: 1
           t:
@@ -1980,6 +1982,8 @@ components:
     JsonPatchRequest:
       title: JsonPatchRequest
       type: array
+      minItems: 1
+      maxItems: 100
       description: >
         A JSON Patch document as defined by RFC 6902.
         Writable fields are: publiccodeYml, url, aliases, active, vitality, analysis.
@@ -2014,6 +2018,7 @@ components:
               - test
           path:
             type: string
+            maxLength: 255
             description: >
               A JSON Pointer (RFC 6901) to a writable field.
               Examples: /publiccodeYml, /url, /active, /vitality, /analysis,
@@ -2024,6 +2029,7 @@ components:
             example: 'name: My Software'
           from:
             type: string
+            maxLength: 255
             description: Source JSON Pointer, used by move and copy operations.
             example: '/aliases/0'
     Software:
@@ -2159,6 +2165,7 @@ components:
         sources:
           type: array
           minItems: 1
+          maxItems: 100
           description: >
             Data sources for this catalog. At least one is
             required on creation.
@@ -2199,10 +2206,13 @@ components:
         url:
           type: string
           format: uri
+          maxLength: 2048
           description: URL of this catalog source
           example: 'https://github.com/org'
         args:
           type: array
+          minItems: 1
+          maxItems: 20
           description: >
             Optional arguments for the driver (e.g. a JSON
             configuration file URL).
@@ -2210,6 +2220,7 @@ components:
           items:
             type: string
             minLength: 1
+            maxLength: 2048
       required:
         - url
     Publisher:


### PR DESCRIPTION
Fixes the warnings flagged by spectral-full.yml that have actionable fixes.

- `JsonPatchRequest`: add `minItems: 1`, `maxItems: 100`
- `JsonPatchRequest.path` / `from`: add `maxLength: 255`
- `AnalysisData.v`: add `minimum: 1`, `maximum: 999`
- `Catalog.sources`: add `maxItems: 100`
- `CatalogSource.url`: add `maxLength: 2048`
- `CatalogSource.args`: add `minItems: 1`, `maxItems: 20`
- `CatalogSource.args.items`: add `maxLength: 2048`

The two remaining warnings (`sec-constrained-additionalProperties` on `AnalysisData`) are intentional — the schema is an open namespace map and cannot use `additionalProperties: false`.