### PR TITLE
feat: enforce maxItems: 100 on Catalog.sources

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -769,4 +769,54 @@ func TestCatalogSourcesDBChecks(t *testing.T) {
 		require.Equal(t, 1, len(args))
 		assert.Equal(t, "$.items[*].url", args[0])
 	})
+
+	t.Run("POST rejects more than 100 sources", func(t *testing.T) {
+		loadFixtures(t)
+
+		var b strings.Builder
+		b.WriteString(`{"name":"Too Many Sources","sources":[`)
+		for i := range 101 {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `{"url":"https://example.org/source%d"}`, i)
+		}
+		b.WriteString("]}")
+
+		req, err := newTestRequest("POST", "/v1/catalogs", strings.NewReader(b.String()))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("PATCH rejects more than 100 sources", func(t *testing.T) {
+		loadFixtures(t)
+
+		var b strings.Builder
+		b.WriteString(`{"sources":[`)
+		for i := range 101 {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `{"url":"https://example.org/source%d"}`, i)
+		}
+		b.WriteString("]}")
+
+		req, err := newTestRequest("PATCH", "/v1/catalogs/"+italiaID, strings.NewReader(b.String()))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
 }

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -28,7 +28,7 @@ type CatalogPost struct {
 	AlternativeID       *string       `json:"alternativeId" validate:"omitempty,min=1,max=255"`
 	Active              *bool         `json:"active"`
 	PublishersNamespace *string       `json:"publishersNamespace" validate:"omitempty,max=255"`
-	Sources             []SourceInput `json:"sources" validate:"required,gt=0,dive"`
+	Sources             []SourceInput `json:"sources" validate:"required,gt=0,max=100,dive"`
 }
 
 type CatalogPatch struct {
@@ -36,7 +36,7 @@ type CatalogPatch struct {
 	AlternativeID       *string        `json:"alternativeId" validate:"omitempty,max=255"`
 	Active              *bool          `json:"active"`
 	PublishersNamespace *string        `json:"publishersNamespace" validate:"omitempty,max=255"`
-	Sources             *[]SourceInput `json:"sources" validate:"omitempty,gt=0,dive"`
+	Sources             *[]SourceInput `json:"sources" validate:"omitempty,gt=0,max=100,dive"`
 }
 
 type PublisherPost struct {

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2079,6 +2079,7 @@ components:
         sources:
           type: array
           minItems: 1
+          maxItems: 100
           description: >
             Data sources for this catalog. At least one is
             required on creation.


### PR DESCRIPTION
Backs the `maxItems: 100` constraint on `Catalog.sources` with actual enforcement in the request validation layer.

Previously the limit existed only in the OAS spec (added in #361) without any code check. Now `go-playground/validator` rejects requests with more than 100 sources and returns 422.

Part of #361.