### PR TITLE
feat: enforce maxLength: 2048 on CatalogSource.url

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -819,4 +819,40 @@ func TestCatalogSourcesDBChecks(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 422, res.StatusCode)
 	})
+
+	t.Run("POST rejects source URL longer than 2048 chars", func(t *testing.T) {
+		loadFixtures(t)
+
+		longURL := "https://example.org/" + strings.Repeat("x", 2029)
+		body := fmt.Sprintf(`{"name":"Long URL","sources":[{"url":%q}]}`, longURL)
+
+		req, err := newTestRequest("POST", "/v1/catalogs", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("PATCH rejects source URL longer than 2048 chars", func(t *testing.T) {
+		loadFixtures(t)
+
+		longURL := "https://example.org/" + strings.Repeat("x", 2029)
+		body := fmt.Sprintf(`{"sources":[{"url":%q}]}`, longURL)
+
+		req, err := newTestRequest("PATCH", "/v1/catalogs/"+italiaID, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
 }

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -19,7 +19,7 @@ func NormalizeURL(rawURL string) string {
 
 type SourceInput struct {
 	Driver *string  `json:"driver" validate:"omitempty,min=1,max=64"`
-	URL    string   `json:"url" validate:"required,url"`
+	URL    string   `json:"url" validate:"required,url,max=2048"`
 	Args   []string `json:"args" validate:"omitempty,dive,min=1"`
 }
 

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2200,6 +2200,7 @@ components:
         url:
           type: string
           format: uri
+          maxLength: 2048
           description: URL of this catalog source
           example: 'https://github.com/org'
         args:


### PR DESCRIPTION
Backs the `maxLength: 2048` constraint on `CatalogSource.url` with actual enforcement in the request validation layer.

The `url` field in `SourceInput` now carries a `max=2048` validator tag, so the API returns 422 when a source URL exceeds 2048 characters, matching the OAS spec.

Part of #361.