### PR TITLE
feat: enforce minItems/maxItems/maxLength on CatalogSource.args

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -855,4 +855,47 @@ func TestCatalogSourcesDBChecks(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 422, res.StatusCode)
 	})
+
+	t.Run("POST rejects source with more than 20 args", func(t *testing.T) {
+		loadFixtures(t)
+
+		var b strings.Builder
+		b.WriteString(`{"name":"Too Many Args","sources":[{"url":"https://example.org/repo","args":[`)
+		for i := range 21 {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `"arg%d"`, i)
+		}
+		b.WriteString("]}]}")
+
+		req, err := newTestRequest("POST", "/v1/catalogs", strings.NewReader(b.String()))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
+
+	t.Run("POST rejects source with arg longer than 2048 chars", func(t *testing.T) {
+		loadFixtures(t)
+
+		longArg := strings.Repeat("x", 2049)
+		body := fmt.Sprintf(`{"name":"Long Arg","sources":[{"url":"https://example.org/repo","args":[%q]}]}`, longArg)
+
+		req, err := newTestRequest("POST", "/v1/catalogs", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 422, res.StatusCode)
+	})
 }

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -20,7 +20,7 @@ func NormalizeURL(rawURL string) string {
 type SourceInput struct {
 	Driver *string  `json:"driver" validate:"omitempty,min=1,max=64"`
 	URL    string   `json:"url" validate:"required,url,max=2048"`
-	Args   []string `json:"args" validate:"omitempty,dive,min=1"`
+	Args   []string `json:"args" validate:"omitempty,min=1,max=20,dive,min=1,max=2048"`
 }
 
 type CatalogPost struct {

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2205,6 +2205,8 @@ components:
           example: 'https://github.com/org'
         args:
           type: array
+          minItems: 1
+          maxItems: 20
           description: >
             Optional arguments for the driver (e.g. a JSON
             configuration file URL).
@@ -2212,6 +2214,7 @@ components:
           items:
             type: string
             minLength: 1
+            maxLength: 2048
       required:
         - url
     Publisher:


### PR DESCRIPTION
Backs the `args` constraints on `CatalogSource` with actual enforcement in the request validation layer.

- `args` must have 1 to 20 items when provided (minItems/maxItems)
- each item must be at most 2048 characters (maxLength)

Part of #361.