### PR TITLE
feat: enforce minimum/maximum on AnalysisData.v

### DIFF
--- a/internal/common/analysis.go
+++ b/internal/common/analysis.go
@@ -14,6 +14,7 @@ var (
 	errAnalysisNotObject    = errors.New("must be a JSON object")
 	errAnalysisMissingV     = errors.New("missing required field 'v'")
 	errAnalysisInvalidV     = errors.New("'v' must be an integer")
+	errAnalysisVOutOfRange  = errors.New("'v' must be between 1 and 999")
 	errAnalysisUnexpectedDB = errors.New("unexpected database value type for analysis")
 )
 
@@ -90,6 +91,10 @@ func WithTimestamps(analysis AnalysisData, now time.Time) (AnalysisData, error) 
 		var version int
 		if err := json.Unmarshal(*meta.V, &version); err != nil {
 			return nil, fmt.Errorf("analysis.%s: %w", namespace, errAnalysisInvalidV)
+		}
+
+		if version < 1 || version > 999 {
+			return nil, fmt.Errorf("analysis.%s: %w", namespace, errAnalysisVOutOfRange)
 		}
 
 		result[namespace], _ = jsonpatch.MergePatch(raw, tPatch)

--- a/internal/common/analysis_test.go
+++ b/internal/common/analysis_test.go
@@ -94,4 +94,44 @@ func TestWithTimestamps(t *testing.T) {
 
 		assert.ErrorIs(t, err, errAnalysisNotObject)
 	})
+
+	t.Run("v below 1 returns error", func(t *testing.T) {
+		input := AnalysisData{
+			"scanner": json.RawMessage(`{"v": 0}`),
+		}
+
+		_, err := WithTimestamps(input, now)
+
+		assert.ErrorIs(t, err, errAnalysisVOutOfRange)
+	})
+
+	t.Run("v above 999 returns error", func(t *testing.T) {
+		input := AnalysisData{
+			"scanner": json.RawMessage(`{"v": 1000}`),
+		}
+
+		_, err := WithTimestamps(input, now)
+
+		assert.ErrorIs(t, err, errAnalysisVOutOfRange)
+	})
+
+	t.Run("v at boundary 1 is valid", func(t *testing.T) {
+		input := AnalysisData{
+			"scanner": json.RawMessage(`{"v": 1}`),
+		}
+
+		_, err := WithTimestamps(input, now)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("v at boundary 999 is valid", func(t *testing.T) {
+		input := AnalysisData{
+			"scanner": json.RawMessage(`{"v": 999}`),
+		}
+
+		_, err := WithTimestamps(input, now)
+
+		assert.NoError(t, err)
+	})
 }

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -1962,6 +1962,8 @@ components:
           v:
             type: integer
             format: int32
+            minimum: 1
+            maximum: 999
             description: Schema version of this namespace.
             example: 1
           t:


### PR DESCRIPTION
Backs the `minimum: 1` / `maximum: 999` constraints on `AnalysisData.v` with actual enforcement.

`WithTimestamps` now returns an error when `v` is outside the 1-999 range, which causes the handler to return 422, matching the OAS spec.

Part of #361.