### PR TITLE
feat: enforce minItems/maxItems/maxLength on JsonPatchRequest

### DIFF
--- a/internal/common/jsonpatch.go
+++ b/internal/common/jsonpatch.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+)
+
+const (
+	maxJSONPatchOps     = 100
+	maxJSONPatchPathLen = 255
+)
+
+var (
+	errJSONPatchEmpty   = errors.New("patch must contain at least one operation")
+	errJSONPatchTooMany = fmt.Errorf("patch must not exceed %d operations", maxJSONPatchOps)
+	errJSONPatchPathLen = fmt.Errorf("path and from must not exceed %d characters", maxJSONPatchPathLen)
+)
+
+// ValidateJSONPatch checks that a decoded patch satisfies the OAS constraints:
+// 1 to 100 operations, path and from at most 255 characters each.
+func ValidateJSONPatch(patch jsonpatch.Patch) error {
+	if len(patch) < 1 {
+		return errJSONPatchEmpty
+	}
+
+	if len(patch) > maxJSONPatchOps {
+		return errJSONPatchTooMany
+	}
+
+	for _, op := range patch {
+		if path, err := op.Path(); err == nil && len(path) > maxJSONPatchPathLen {
+			return errJSONPatchPathLen
+		}
+
+		if from, err := op.From(); err == nil && len(from) > maxJSONPatchPathLen {
+			return errJSONPatchPathLen
+		}
+	}
+
+	return nil
+}

--- a/internal/common/jsonpatch_test.go
+++ b/internal/common/jsonpatch_test.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustDecodePatch(t *testing.T, raw string) jsonpatch.Patch {
+	t.Helper()
+
+	patch, err := jsonpatch.DecodePatch([]byte(raw))
+	require.NoError(t, err)
+
+	return patch
+}
+
+func TestValidateJSONPatch(t *testing.T) {
+	t.Run("valid single op", func(t *testing.T) {
+		patch := mustDecodePatch(t, `[{"op":"replace","path":"/active","value":true}]`)
+
+		assert.NoError(t, ValidateJSONPatch(patch))
+	})
+
+	t.Run("empty patch returns error", func(t *testing.T) {
+		patch := mustDecodePatch(t, `[]`)
+
+		assert.ErrorIs(t, ValidateJSONPatch(patch), errJSONPatchEmpty)
+	})
+
+	t.Run("patch with 101 ops returns error", func(t *testing.T) {
+		var ops []string
+		for range 101 {
+			ops = append(ops, `{"op":"replace","path":"/active","value":true}`)
+		}
+
+		patch := mustDecodePatch(t, "["+strings.Join(ops, ",")+"]")
+
+		assert.ErrorIs(t, ValidateJSONPatch(patch), errJSONPatchTooMany)
+	})
+
+	t.Run("path longer than 255 chars returns error", func(t *testing.T) {
+		longPath := "/" + strings.Repeat("x", 255)
+		raw := `[{"op":"replace","path":"` + longPath + `","value":true}]`
+		patch := mustDecodePatch(t, raw)
+
+		assert.ErrorIs(t, ValidateJSONPatch(patch), errJSONPatchPathLen)
+	})
+
+	t.Run("path exactly 255 chars is valid", func(t *testing.T) {
+		okPath := "/" + strings.Repeat("x", 254)
+		raw := `[{"op":"replace","path":"` + okPath + `","value":true}]`
+		patch := mustDecodePatch(t, raw)
+
+		assert.NoError(t, ValidateJSONPatch(patch))
+	})
+}

--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -181,6 +181,10 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop,funlen
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
 		}
 
+		if err := common.ValidateJSONPatch(patch); err != nil {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+		}
+
 		updatedJSON, err = patch.Apply(catalogJSON)
 		if err != nil {
 			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
@@ -477,6 +481,10 @@ func (c *Catalog) PatchCatalogPublisher(ctx *fiber.Ctx) error { //nolint:cyclop,
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
 		}
 
+		if err := common.ValidateJSONPatch(patch); err != nil {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+		}
+
 		updatedJSON, err = patch.Apply(publisherJSON)
 		if err != nil {
 			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
@@ -657,6 +665,10 @@ func (c *Catalog) PatchCatalogSoftware(ctx *fiber.Ctx) error { //nolint:funlen,c
 		patch, err := jsonpatch.DecodePatch(ctx.Body())
 		if err != nil {
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
+		}
+
+		if err := common.ValidateJSONPatch(patch); err != nil {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
 		}
 
 		updatedJSON, err = patch.Apply(softwareJSON)

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -189,6 +189,10 @@ func (p *Publisher) PatchPublisher(ctx *fiber.Ctx) error { //nolint:cyclop,funle
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
 		}
 
+		if err := common.ValidateJSONPatch(patch); err != nil {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+		}
+
 		updatedJSON, err = patch.Apply(publisherJSON)
 		if err != nil {
 			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -205,6 +205,10 @@ func (p *Software) PatchSoftware(ctx *fiber.Ctx) error { //nolint:funlen,cyclop
 			return common.Error(fiber.StatusBadRequest, errMsg, errMalformedJSONPatch.Error())
 		}
 
+		if err := common.ValidateJSONPatch(patch); err != nil {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())
+		}
+
 		updatedJSON, err = patch.Apply(softwareJSON)
 		if err != nil {
 			return common.Error(fiber.StatusUnprocessableEntity, errMsg, err.Error())

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -1982,6 +1982,8 @@ components:
     JsonPatchRequest:
       title: JsonPatchRequest
       type: array
+      minItems: 1
+      maxItems: 100
       description: >
         A JSON Patch document as defined by RFC 6902.
         Writable fields are: publiccodeYml, url, aliases, active, vitality, analysis.
@@ -2016,6 +2018,7 @@ components:
               - test
           path:
             type: string
+            maxLength: 255
             description: >
               A JSON Pointer (RFC 6901) to a writable field.
               Examples: /publiccodeYml, /url, /active, /vitality, /analysis,
@@ -2026,6 +2029,7 @@ components:
             example: 'name: My Software'
           from:
             type: string
+            maxLength: 255
             description: Source JSON Pointer, used by move and copy operations.
             example: '/aliases/0'
     Software:

--- a/software_test.go
+++ b/software_test.go
@@ -888,6 +888,57 @@ func TestSoftwareEndpoints(t *testing.T) {
 			},
 		},
 		{
+			description: "PATCH a software resource with JSON Patch - empty patch rejected",
+			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
+			body:        `[]`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json-patch+json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't update Software", response["title"])
+				assert.Equal(t, "patch must contain at least one operation", response["detail"])
+			},
+		},
+		{
+			description: "PATCH a software resource with JSON Patch - too many ops rejected",
+			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
+			body: func() string {
+				ops := make([]string, 101)
+				for i := range ops {
+					ops[i] = `{"op":"replace","path":"/active","value":true}`
+				}
+				return "[" + strings.Join(ops, ",") + "]"
+			}(),
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json-patch+json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't update Software", response["title"])
+				assert.Equal(t, "patch must not exceed 100 operations", response["detail"])
+			},
+		},
+		{
+			description: "PATCH a software resource with JSON Patch - path too long rejected",
+			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
+			body:        `[{"op":"replace","path":"/` + strings.Repeat("x", 255) + `","value":true}]`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json-patch+json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't update Software", response["title"])
+				assert.Equal(t, "path and from must not exceed 255 characters", response["detail"])
+			},
+		},
+		{
 			description: "PATCH software using an already taken URL as url",
 			query:       "PATCH /v1/software/59803fb7-8eec-4fe5-a354-8926009c364a",
 			body:        `{"url": "https://15-b.example.org/code/repo"}`,


### PR DESCRIPTION
Backs the `JsonPatchRequest` constraints with actual enforcement across all PATCH endpoints that accept `application/json-patch+json`.

- patches must have 1 to 100 operations (minItems/maxItems)
- `path` and `from` pointers must not exceed 255 characters (maxLength)

Adds `ValidateJSONPatch` in `internal/common` and calls it from `PatchSoftware`, `PatchCatalog`, `PatchCatalogPublisher`, `PatchCatalogSoftware`, and `PatchPublisher`.

Part of #361.