### PR TITLE
fix: preserve query parameters in pagination links

### DIFF
--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -86,7 +86,7 @@ func (c *Catalog) GetCatalogs(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &catalogs, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &catalogs, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // GetCatalog gets the catalog with the given id.
@@ -353,7 +353,7 @@ func (c *Catalog) GetCatalogPublishers(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &publishers, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &publishers, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // PostCatalogPublisher creates a publisher belonging to the given catalog.
@@ -803,7 +803,7 @@ func (c *Catalog) GetCatalogSoftware(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &software, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &software, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // buildSources converts SourceInput slice to CatalogSource models.

--- a/internal/handlers/general/pagination.go
+++ b/internal/handlers/general/pagination.go
@@ -2,7 +2,10 @@ package general
 
 import (
 	"encoding/json"
-	"fmt"
+	"maps"
+	"net/url"
+	"slices"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/pilagod/gorm-cursor-paginator/v2/paginator"
@@ -16,7 +19,39 @@ var DefaultConfig = &paginator.Config{ //nolint:gochecknoglobals //can't turn it
 	Order: paginator.ASC,
 }
 
-type PaginationLinks paginator.Cursor
+type PaginationLinks struct {
+	prev *string
+	next *string
+}
+
+func NewPaginationLinks(queries map[string]string, cursor paginator.Cursor) PaginationLinks {
+	base := maps.Clone(queries)
+	delete(base, "page[after]")
+	delete(base, "page[before]")
+
+	return PaginationLinks{
+		prev: buildLink(base, "page[before]", cursor.Before),
+		next: buildLink(base, "page[after]", cursor.After),
+	}
+}
+
+func buildLink(base map[string]string, key string, cursor *string) *string {
+	if cursor == nil {
+		return nil
+	}
+
+	params := maps.Clone(base)
+	params[key] = *cursor
+
+	parts := make([]string, 0, len(params))
+	for _, k := range slices.Sorted(maps.Keys(params)) {
+		parts = append(parts, k+"="+url.QueryEscape(params[k]))
+	}
+
+	s := "?" + strings.Join(parts, "&")
+
+	return &s
+}
 
 func NewPaginator(ctx *fiber.Ctx) *paginator.Paginator {
 	return NewPaginatorWithConfig(ctx, DefaultConfig)
@@ -55,22 +90,12 @@ func NewPaginatorWithConfig(ctx *fiber.Ctx, config *paginator.Config) *paginator
 	return paginator
 }
 
-func createLink(cursor *string, field string) *string {
-	if cursor != nil {
-		res := fmt.Sprintf("?page[%s]=%s", field, *cursor)
-
-		return &res
-	}
-
-	return nil
-}
-
 func (links PaginationLinks) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Prev *string `json:"prev"`
 		Next *string `json:"next"`
 	}{
-		Prev: createLink(links.Before, "before"),
-		Next: createLink(links.After, "after"),
+		Prev: links.prev,
+		Next: links.next,
 	})
 }

--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -66,7 +66,7 @@ func (p *Log) GetLogs(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &logs, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &logs, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // GetLog gets the log with the given ID and returns any error encountered.
@@ -195,7 +195,7 @@ func (p *Log) GetSoftwareLogs(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &logs, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &logs, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // PostCatalogLog creates a new log associated to a Catalog with the given ID and returns any error encountered.

--- a/internal/handlers/publishers.go
+++ b/internal/handlers/publishers.go
@@ -75,7 +75,7 @@ func (p *Publisher) GetPublishers(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &publishers, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &publishers, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // GetPublisher gets the publisher with the given ID and returns any error encountered.

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -121,7 +121,7 @@ func (p *Software) GetAllSoftware(ctx *fiber.Ctx) error { //nolint:cyclop // mos
 		}
 	}
 
-	return ctx.JSON(fiber.Map{"data": &software, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &software, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // GetSoftware gets the software with the given ID and returns any error encountered.

--- a/internal/handlers/webhooks.go
+++ b/internal/handlers/webhooks.go
@@ -66,7 +66,7 @@ func (p *Webhook[T]) GetResourceWebhooks(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &webhooks, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &webhooks, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // GetSingleResourceWebhooks gets the webhooks associated to a resource
@@ -112,7 +112,7 @@ func (p *Webhook[T]) GetSingleResourceWebhooks(ctx *fiber.Ctx) error {
 		)
 	}
 
-	return ctx.JSON(fiber.Map{"data": &webhooks, "links": general.PaginationLinks(cursor)})
+	return ctx.JSON(fiber.Map{"data": &webhooks, "links": general.NewPaginationLinks(ctx.Queries(), cursor)})
 }
 
 // PostResourceWebhook creates a new webhook associated to resources

--- a/logs_test.go
+++ b/logs_test.go
@@ -70,7 +70,25 @@ func TestLogsEndpoints(t *testing.T) {
 
 				assert.Equal(t, 3, len(data))
 
-				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDEwLTA4LTAxVDIzOjU5OjU5WiIsIjRiNGExYjljLTA0MmUtMTFlZC04MmE4LWQ4YmJjMTQ2ZDE2NSJd")
+				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDEwLTA4LTAxVDIzOjU5OjU5WiIsIjRiNGExYjljLTA0MmUtMTFlZC04MmE4LWQ4YmJjMTQ2ZDE2NSJd&page[size]=3")
+			},
+		},
+		{
+			description: "GET with from and page[size] preserves both in links",
+			query:       "GET /v1/logs?from=2010-03-01T09:56:23Z&page[size]=3",
+
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				data := assertListResponse(t, response)
+
+				assert.Equal(t, 3, len(data))
+
+				links := response["links"].(map[string]interface{})
+				next := links["next"].(string)
+				assert.Contains(t, next, "from=2010-03-01T09%3A56%3A23Z")
+				assert.Contains(t, next, "page[after]=")
+				assert.Contains(t, next, "page[size]=3")
 			},
 		},
 		// TODO

--- a/publishers_test.go
+++ b/publishers_test.go
@@ -94,7 +94,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 				assert.Equal(t, 2, len(data))
 
-				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE4LTA1LTE2VDAwOjAwOjAwWiIsIjQ3ODA3ZTBjLTA2MTMtNGFlYS05OTE3LTU0NTVjYzZlZGRhZCJd")
+				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE4LTA1LTE2VDAwOjAwOjAwWiIsIjQ3ODA3ZTBjLTA2MTMtNGFlYS05OTE3LTU0NTVjYzZlZGRhZCJd&page[size]=2")
 			},
 		},
 		// TODO
@@ -947,7 +947,7 @@ func TestPublishersEndpoints(t *testing.T) {
 
 				assert.Equal(t, 1, len(data))
 
-				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE4LTA3LTE1VDAwOjAwOjAwWiIsIjhmMzczYThjLTFmNTUtNDVlNC04NTQ5LTA1Y2Q2MzJhMmFkZCJd")
+				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE4LTA3LTE1VDAwOjAwOjAwWiIsIjhmMzczYThjLTFmNTUtNDVlNC04NTQ5LTA1Y2Q2MzJhMmFkZCJd&page[size]=1")
 			},
 		},
 

--- a/software_test.go
+++ b/software_test.go
@@ -180,7 +180,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, 2, len(data))
 
-				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE0LTA1LTE2VDAwOjAwOjAwWiIsIjlmMTM1MjY4LWEzN2UtNGVhZC05NmVjLWU0YTI0YmI5MzQ0YSJd")
+				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE0LTA1LTE2VDAwOjAwOjAwWiIsIjlmMTM1MjY4LWEzN2UtNGVhZC05NmVjLWU0YTI0YmI5MzQ0YSJd&page[size]=2")
 			},
 		},
 		// TODO
@@ -1101,7 +1101,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, 2, len(data))
 
-				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDEwLTAxLTE1VDIzOjU5OjU5WiIsIjEyZjMwZDllLTA0MmUtMTFlZC04ZGRjLWQ4YmJjMTQ2ZDE2NSJd")
+				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDEwLTAxLTE1VDIzOjU5OjU5WiIsIjEyZjMwZDllLTA0MmUtMTFlZC04ZGRjLWQ4YmJjMTQ2ZDE2NSJd&page[size]=2")
 			},
 		},
 
@@ -1278,7 +1278,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 
 				assert.Equal(t, 1, len(data))
 
-				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE3LTA1LTAxVDAwOjAwOjAwWiIsImQ2MzM0MDAwLTY5YTgtNDNhMS1hYjQzLTUwYmIwNGUxNGVlZCJd")
+				assertPaginationLinks(t, response, nil, "?page[after]=WyIyMDE3LTA1LTAxVDAwOjAwOjAwWiIsImQ2MzM0MDAwLTY5YTgtNDNhMS1hYjQzLTUwYmIwNGUxNGVlZCJd&page[size]=1")
 			},
 		},
 


### PR DESCRIPTION
Pagination links only contained the cursor parameter, dropping all other query parameters (from, to, page[size], filter, etc.) from the original request. Clients following a next/prev link would lose their filters.

Fix #357.