### PR TITLE
feat: add scopes to catalogs

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -146,6 +146,49 @@ func TestCatalogEndpoints(t *testing.T) {
 			expectedContentType: "application/problem+json",
 			expectedBody:        `{"title":"token authentication failed","status":401}`,
 		},
+		{
+			description: "POST catalog with mixed scopes",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "EU Catalog", "scopes": ["m49:150", "iso3166:IT", "iso3166:IT-25"], "sources": [{"url": "https://github.com/example/eu"}]}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t,
+					[]interface{}{"m49:150", "iso3166:IT", "iso3166:IT-25"},
+					response["scopes"],
+				)
+			},
+		},
+		{
+			description: "POST catalog with bare scope",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "Lombardia Catalog", "scopes": ["IT-25"], "sources": [{"url": "https://github.com/example/lombardia"}]}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, []interface{}{"IT-25"}, response["scopes"])
+			},
+		},
+		{
+			description: "POST catalog with empty scope item",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "Bad", "scopes": [""], "sources": [{"url": "https://github.com/example/bad"}]}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't create Catalog","detail":"invalid format: scopes[0] does not meet its size limits (too short)","status":422,"validationErrors":[{"field":"scopes[0]","rule":"min","value":""}]}`,
+		},
 
 		// PATCH /catalogs/:id
 		{

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -28,6 +28,7 @@ type CatalogPost struct {
 	AlternativeID       *string       `json:"alternativeId" validate:"omitempty,min=1,max=255"`
 	Active              *bool         `json:"active"`
 	PublishersNamespace *string       `json:"publishersNamespace" validate:"omitempty,max=255"`
+	Scopes              []string      `json:"scopes" validate:"omitempty,max=20,dive,min=1,max=64"`
 	Sources             []SourceInput `json:"sources" validate:"required,gt=0,max=100,dive"`
 }
 
@@ -36,6 +37,7 @@ type CatalogPatch struct {
 	AlternativeID       *string        `json:"alternativeId" validate:"omitempty,max=255"`
 	Active              *bool          `json:"active"`
 	PublishersNamespace *string        `json:"publishersNamespace" validate:"omitempty,max=255"`
+	Scopes              *[]string      `json:"scopes" validate:"omitempty,max=20,dive,min=1,max=64"`
 	Sources             *[]SourceInput `json:"sources" validate:"omitempty,gt=0,max=100,dive"`
 }
 

--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -125,6 +125,7 @@ func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
 		Name:          request.Name,
 		AlternativeID: request.AlternativeID,
 		Active:        request.Active,
+		Scopes:        request.Scopes,
 		Sources:       sources,
 	}
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -38,6 +38,7 @@ type Catalog struct {
 	AlternativeID       *string         `json:"alternativeId,omitempty" gorm:"uniqueIndex"`
 	Active              *bool           `json:"active" gorm:"default:true;not null"`
 	PublishersNamespace *string         `json:"publishersNamespace,omitempty"`
+	Scopes              []string        `json:"scopes,omitempty" gorm:"serializer:json"`
 	Sources             []CatalogSource `json:"sources" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	CreatedAt           time.Time       `json:"createdAt" gorm:"index"`
 	UpdatedAt           time.Time       `json:"updatedAt"`

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2162,6 +2162,27 @@ components:
             each publiccode.yml organisation field equals
             this prefix + the publisher alternativeId.
           example: 'urn:x-italian-pa:'
+        scopes:
+          type: array
+          maxItems: 20
+          description: >
+            Optional list of identifiers of the places this catalog
+            covers. The conventional form is `<scheme>:<code>`, with
+            `iso3166` (country alpha-2 codes and subdivisions, e.g.
+            `IT`, `IT-25`) and `m49` (UN M.49 numeric codes) as
+            common schemes; a bare value is interpreted as `iso3166`.
+            The format is not enforced server side: any non-empty
+            string up to 64 characters is accepted. An empty or
+            absent list means the catalog is thematic and not tied
+            to a specific place.
+          items:
+            type: string
+            minLength: 1
+            maxLength: 64
+            example: 'iso3166:IT-25'
+          example:
+            - 'iso3166:IT'
+            - 'm49:150'
         sources:
           type: array
           minItems: 1


### PR DESCRIPTION
A catalog can now declare which place(s) it covers as a list of free form identifiers. The conventional form is `<scheme>:<code>`, with `iso3166` (e.g. `IT`, `IT-25`) and `m49` as common schemes, but the format is not enforced server side: any non-empty string up to 64 characters is accepted, with a cap of 20 entries per catalog. An empty or absent list means the catalog is thematic.

Fix #371.