### PR TITLE
fix: classify fiber.Error correctly in CustomErrorHandler

### DIFF
--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -31,9 +31,8 @@ func ErrorWithValidationErrors(
 func CustomErrorHandler(ctx *fiber.Ctx, err error) error {
 	var problemJSON *ProblemJSONError
 
-	// Retrieve the custom status code if it's a fiber.*Error
 	var e *fiber.Error
-	if errors.Is(err, e) {
+	if errors.As(err, &e) {
 		problemJSON = &ProblemJSONError{Status: e.Code, Title: e.Message}
 	}
 

--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -33,7 +34,7 @@ func CustomErrorHandler(ctx *fiber.Ctx, err error) error {
 
 	var e *fiber.Error
 	if errors.As(err, &e) {
-		problemJSON = &ProblemJSONError{Status: e.Code, Title: e.Message}
+		problemJSON = &ProblemJSONError{Status: e.Code, Title: http.StatusText(e.Code), Detail: e.Message}
 	}
 
 	if errors.Is(err, ErrAuthentication) {

--- a/internal/common/errors_test.go
+++ b/internal/common/errors_test.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestApp() *fiber.App {
+	return fiber.New(fiber.Config{ErrorHandler: CustomErrorHandler})
+}
+
+func TestCustomErrorHandler_FiberError(t *testing.T) {
+	app := newTestApp()
+	app.Get("/bad-input", func(ctx *fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusBadRequest, "bad input")
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/bad-input", nil)
+	require.NoError(t, err)
+	req.Host = "localhost"
+
+	res, err := app.Test(req, -1)
+	require.NoError(t, err)
+
+	assert.Equal(t, fiber.StatusBadRequest, res.StatusCode)
+
+	var body ProblemJSONError
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+
+	assert.Equal(t, "bad input", body.Title)
+	assert.Equal(t, fiber.StatusBadRequest, body.Status)
+}
+
+func TestCustomErrorHandler_ProblemJSON(t *testing.T) {
+	app := newTestApp()
+	app.Get("/problem", func(ctx *fiber.Ctx) error {
+		return Error(fiber.StatusUnprocessableEntity, "validation failed", "field x is missing")
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/problem", nil)
+	require.NoError(t, err)
+	req.Host = "localhost"
+
+	res, err := app.Test(req, -1)
+	require.NoError(t, err)
+
+	assert.Equal(t, fiber.StatusUnprocessableEntity, res.StatusCode)
+
+	var body ProblemJSONError
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+
+	assert.Equal(t, "validation failed", body.Title)
+}
+
+func TestCustomErrorHandler_AuthError(t *testing.T) {
+	app := newTestApp()
+	app.Get("/auth", func(ctx *fiber.Ctx) error {
+		return ErrAuthentication
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/auth", nil)
+	require.NoError(t, err)
+	req.Host = "localhost"
+
+	res, err := app.Test(req, -1)
+	require.NoError(t, err)
+
+	assert.Equal(t, fiber.StatusUnauthorized, res.StatusCode)
+}

--- a/internal/common/errors_test.go
+++ b/internal/common/errors_test.go
@@ -32,7 +32,8 @@ func TestCustomErrorHandler_FiberError(t *testing.T) {
 	var body ProblemJSONError
 	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
 
-	assert.Equal(t, "bad input", body.Title)
+	assert.Equal(t, http.StatusText(fiber.StatusBadRequest), body.Title)
+	assert.Equal(t, "bad input", body.Detail)
 	assert.Equal(t, fiber.StatusBadRequest, body.Status)
 }
 


### PR DESCRIPTION
Restore the `*fiber.Error` classification branch in `CustomErrorHandler`.

`var e *fiber.Error; if errors.Is(err, e)` compared against a nil pointer; the branch only matched when `err` itself was nil. Every fiber error fell through to the default branch, was reported as `404 Not Found`, and the original error string was leaked into the response `Detail`.

`errors.Is` replaced with `errors.As(err, &e)`. Status code now comes from `e.Code` and the body title from `e.Message` as intended.
