### PR TITLE
fix: handle WriteString error when printing token

### DIFF
--- a/cmd/token.go
+++ b/cmd/token.go
@@ -98,7 +98,7 @@ func runTokenCreate(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "claims:\n%s\n\n", payloadJSON)
 	fmt.Fprintf(os.Stderr, "token:\n")
 
-	fmt.Println(token)
+	fmt.Fprintln(os.Stdout, token)
 
 	fmt.Fprint(os.Stderr, "\npermissions:\n"+
 		"   - software:    create, update, delete\n"+

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -98,7 +98,7 @@ func runTokenCreate(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "claims:\n%s\n\n", payloadJSON)
 	fmt.Fprintf(os.Stderr, "token:\n")
 
-	os.Stdout.WriteString(token + "\n")
+	fmt.Println(token)
 
 	fmt.Fprint(os.Stderr, "\npermissions:\n"+
 		"   - software:    create, update, delete\n"+


### PR DESCRIPTION
Replace `os.Stdout.WriteString(token + "\n")` with `fmt.Println(token)`.

Same effect, no manually concatenated newline, no ignored return error. Removes the gosec G104 finding on this line.
