### PR TITLE
feat: enforce min/max length on webhook secret

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -84,7 +84,7 @@ type Log struct {
 
 type Webhook struct {
 	URL    string `json:"url" validate:"required,url"`
-	Secret string `json:"secret"`
+	Secret string `json:"secret" validate:"omitempty,min=16,max=256"`
 }
 
 func NormalizeEmail(email *string) *string {

--- a/publishers_test.go
+++ b/publishers_test.go
@@ -969,7 +969,7 @@ func TestPublishersEndpoints(t *testing.T) {
 		},
 		{
 			query: "POST /v1/publishers/98a069f7-57b0-464d-b300-4b4b336297a0/webhooks",
-			body:  `{"url": "https://new.example.org", "secret": "xyz"}`,
+			body:  `{"url": "https://new.example.org", "secret": "1234567890abcdef"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2557,11 +2557,11 @@ components:
           description: URL where the webhook payload will be delivered to
         secret:
           type: string
-          maxLength: 255
-          pattern: '.*'
+          minLength: 16
+          maxLength: 256
           description: |
             Secret used to authenticate to the webhook endpoint
-          example: 'my-secret-token'
+          example: 'my-secret-token-16c'
         createdAt:
           type: string
           description: The time the webhook was created (RFC 3339 datetime)

--- a/software_test.go
+++ b/software_test.go
@@ -1351,7 +1351,7 @@ func TestSoftwareEndpoints(t *testing.T) {
 		},
 		{
 			query: "POST /v1/software/c5dec6fa-8a01-4881-9e7d-132770d4214d/webhooks",
-			body:  `{"url": "https://new.example.org", "secret": "xyz"}`,
+			body:  `{"url": "https://new.example.org", "secret": "1234567890abcdef"}`,
 			headers: map[string][]string{
 				"Authorization": {goodToken},
 				"Content-Type":  {"application/json"},

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -8,6 +8,36 @@ import (
 
 func TestWebhooksEndpoints(t *testing.T) {
 	tests := []TestCase{
+		// POST /software/webhooks
+		{
+			description: "POST webhook with too-short secret returns 422",
+			query:       "POST /v1/software/webhooks",
+			body:        `{"url": "https://example.org/receiver", "secret": "tooshort"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assert.Equal(t, "can't create Webhook", response["title"])
+			},
+		},
+		{
+			description: "POST webhook with valid 16-char secret returns 201",
+			query:       "POST /v1/software/webhooks",
+			body:        `{"url": "https://example.org/receiver", "secret": "1234567890abcdef"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        200,
+			expectedContentType: "application/json",
+			validateFunc: func(t *testing.T, response map[string]interface{}) {
+				assertUUID(t, response["id"])
+				assert.Equal(t, "https://example.org/receiver", response["url"])
+			},
+		},
 		// GET /webhooks/:id
 		{
 			query:               "GET /v1/webhooks/007bc84a-7e2d-43a0-b7e1-a256d4114aa7",


### PR DESCRIPTION
Without a minimum, a 1-byte secret makes HMAC-SHA256 trivially weak. 16 bytes is a defensible floor; 256 is a generous ceiling.