### PR TITLE
feat: materialize the root catalog via alternativeId ∅

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -136,7 +136,19 @@ func TestCatalogEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't create Catalog","detail":"invalid format: name is required, sources is required","status":422,"validationErrors":[{"field":"name","rule":"required","value":""},{"field":"sources","rule":"required","value":""}]}`,
+			expectedBody:        `{"title":"can't create Catalog","detail":"invalid format: name is required","status":422,"validationErrors":[{"field":"name","rule":"required","value":""}]}`,
+		},
+		{
+			description: "POST catalog missing sources",
+			query:       "POST /v1/catalogs",
+			body:        `{"name": "Catalog without sources"}`,
+			headers: map[string][]string{
+				"Authorization": {goodToken},
+				"Content-Type":  {"application/json"},
+			},
+			expectedCode:        422,
+			expectedContentType: "application/problem+json",
+			expectedBody:        `{"title":"can't create Catalog","detail":"sources is required","status":422}`,
 		},
 		{
 			description:         "POST catalog - no token",
@@ -940,5 +952,166 @@ func TestCatalogSourcesDBChecks(t *testing.T) {
 		res, err := app.Test(req, -1)
 		require.NoError(t, err)
 		assert.Equal(t, 422, res.StatusCode)
+	})
+}
+
+func TestRootCatalogMaterialize(t *testing.T) {
+	post := func(t *testing.T, path, body string) (int, map[string]interface{}) {
+		t.Helper()
+
+		req, err := newTestRequest("POST", path, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+
+		var resp map[string]interface{}
+		if res.StatusCode == 200 {
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+		}
+
+		return res.StatusCode, resp
+	}
+
+	patch := func(t *testing.T, path, body string) (int, map[string]interface{}) {
+		t.Helper()
+
+		req, err := newTestRequest("PATCH", path, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/json"},
+		}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+
+		return res.StatusCode, resp
+	}
+
+	del := func(t *testing.T, path string) int {
+		t.Helper()
+
+		req, err := newTestRequest("DELETE", path, nil)
+		require.NoError(t, err)
+		req.Header = map[string][]string{"Authorization": {goodToken}}
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+
+		return res.StatusCode
+	}
+
+	t.Run("POST root with sources rejected", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs",
+			`{"name":"Root","alternativeId":"∅","sources":[{"url":"https://x"}]}`)
+		assert.Equal(t, 422, status)
+	})
+
+	t.Run("POST root persists publishersNamespace", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, resp := post(t, "/v1/catalogs",
+			`{"name":"Root","alternativeId":"∅","publishersNamespace":"urn:x-italian-pa:"}`)
+		require.Equal(t, 200, status)
+		assert.Equal(t, "urn:x-italian-pa:", resp["publishersNamespace"])
+		assert.Equal(t, "∅", resp["alternativeId"])
+		assertUUID(t, resp["id"])
+	})
+
+	t.Run("POST duplicate root returns 409", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs", `{"name":"Root","alternativeId":"∅"}`)
+		require.Equal(t, 200, status)
+
+		status, _ = post(t, "/v1/catalogs", `{"name":"Other","alternativeId":"∅"}`)
+		assert.Equal(t, 409, status)
+	})
+
+	t.Run("PATCH root not materialized returns 404", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := patch(t, "/v1/catalogs/%E2%88%85", `{"name":"Renamed"}`)
+		assert.Equal(t, 404, status)
+	})
+
+	t.Run("PATCH root updates name", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs", `{"name":"Root","alternativeId":"∅"}`)
+		require.Equal(t, 200, status)
+
+		status, resp := patch(t, "/v1/catalogs/%E2%88%85", `{"name":"Renamed Root"}`)
+		require.Equal(t, 200, status)
+		assert.Equal(t, "Renamed Root", resp["name"])
+		assert.Equal(t, "∅", resp["alternativeId"])
+	})
+
+	t.Run("PATCH root rejects alternativeId change", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs", `{"name":"Root","alternativeId":"∅"}`)
+		require.Equal(t, 200, status)
+
+		status, resp := patch(t, "/v1/catalogs/%E2%88%85", `{"alternativeId":"renamed"}`)
+		assert.Equal(t, 422, status)
+		assert.Equal(t, "alternativeId on the root catalog cannot be changed", resp["detail"])
+	})
+
+	t.Run("PATCH root rejects sources", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs", `{"name":"Root","alternativeId":"∅"}`)
+		require.Equal(t, 200, status)
+
+		status, resp := patch(t, "/v1/catalogs/%E2%88%85", `{"sources":[{"url":"https://x"}]}`)
+		assert.Equal(t, 422, status)
+		assert.Equal(t, "sources are not allowed on the root catalog", resp["detail"])
+	})
+
+	t.Run("DELETE root not materialized returns 404", func(t *testing.T) {
+		loadFixtures(t)
+
+		assert.Equal(t, 404, del(t, "/v1/catalogs/%E2%88%85"))
+	})
+
+	t.Run("DELETE root with attached resources returns 409", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs", `{"name":"Root","alternativeId":"∅"}`)
+		require.Equal(t, 200, status)
+
+		assert.Equal(t, 409, del(t, "/v1/catalogs/%E2%88%85"))
+	})
+
+	t.Run("GET root publishers visible after materialization", func(t *testing.T) {
+		loadFixtures(t)
+
+		status, _ := post(t, "/v1/catalogs", `{"name":"Root","alternativeId":"∅"}`)
+		require.Equal(t, 200, status)
+
+		req, err := newTestRequest("GET", "/v1/catalogs/%E2%88%85/publishers?all=true", nil)
+		require.NoError(t, err)
+
+		res, err := app.Test(req, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res.StatusCode)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+
+		data, ok := resp["data"].([]interface{})
+		require.True(t, ok, "expected data slice")
+		assert.NotEmpty(t, data, "root publishers (catalog_id IS NULL) should still be visible")
 	})
 }

--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -29,7 +29,7 @@ type CatalogPost struct {
 	Active              *bool         `json:"active"`
 	PublishersNamespace *string       `json:"publishersNamespace" validate:"omitempty,max=255"`
 	Scopes              []string      `json:"scopes" validate:"omitempty,max=20,dive,min=1,max=64"`
-	Sources             []SourceInput `json:"sources" validate:"required,gt=0,max=100,dive"`
+	Sources             []SourceInput `json:"sources" validate:"omitempty,max=100,dive"`
 }
 
 type CatalogPatch struct {

--- a/internal/handlers/catalogs.go
+++ b/internal/handlers/catalogs.go
@@ -121,6 +121,10 @@ func (c *Catalog) GetCatalog(ctx *fiber.Ctx) error {
 }
 
 // PostCatalog creates a new catalog.
+// When alternativeId is "∅" the new row materializes the root catalog: it
+// holds the configuration (sources are not allowed; resources are still
+// addressed via catalog_id IS NULL). For any other catalog at least one
+// source is required.
 func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
 	const errMsg = "can't create Catalog"
 
@@ -130,15 +134,27 @@ func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
 		return err //nolint:wrapcheck
 	}
 
+	asRoot := request.AlternativeID != nil && *request.AlternativeID == rootCatalogID
+
+	if asRoot && len(request.Sources) > 0 {
+		return common.Error(fiber.StatusUnprocessableEntity, errMsg,
+			"sources are not allowed on the root catalog")
+	}
+
+	if !asRoot && len(request.Sources) == 0 {
+		return common.Error(fiber.StatusUnprocessableEntity, errMsg, "sources is required")
+	}
+
 	sources := buildSources(request.Sources)
 
 	catalog := &models.Catalog{
-		ID:            utils.UUIDv4(),
-		Name:          request.Name,
-		AlternativeID: request.AlternativeID,
-		Active:        request.Active,
-		Scopes:        request.Scopes,
-		Sources:       sources,
+		ID:                  utils.UUIDv4(),
+		Name:                request.Name,
+		AlternativeID:       request.AlternativeID,
+		Active:              request.Active,
+		Scopes:              request.Scopes,
+		PublishersNamespace: request.PublishersNamespace,
+		Sources:             sources,
 	}
 
 	if err := c.db.Create(catalog).Error; err != nil {
@@ -158,14 +174,10 @@ func (c *Catalog) PostCatalog(ctx *fiber.Ctx) error {
 }
 
 // PatchCatalog updates the catalog with the given id.
-func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
+func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop,funlen
 	const errMsg = "can't update Catalog"
 
 	catalogID, _ := url.PathUnescape(ctx.Params("id"))
-
-	if catalogID == rootCatalogID {
-		return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
-	}
 
 	resolved, err := resolveCatalog(c.db, catalogID, "Sources")
 	if err != nil {
@@ -196,6 +208,13 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 
 	updatedCatalog.ID = catalog.ID
 
+	if isRoot(&catalog) {
+		if updatedCatalog.AlternativeID == nil || *updatedCatalog.AlternativeID != rootCatalogID {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg,
+				"alternativeId on the root catalog cannot be changed")
+		}
+	}
+
 	sourcesInput := make([]common.SourceInput, 0, len(updatedCatalog.Sources))
 	for _, src := range updatedCatalog.Sources {
 		sourcesInput = append(sourcesInput, common.SourceInput{
@@ -205,7 +224,12 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 		})
 	}
 
-	if len(sourcesInput) == 0 {
+	if isRoot(&catalog) {
+		if len(sourcesInput) > 0 {
+			return common.Error(fiber.StatusUnprocessableEntity, errMsg,
+				"sources are not allowed on the root catalog")
+		}
+	} else if len(sourcesInput) == 0 {
 		return common.Error(fiber.StatusUnprocessableEntity, errMsg, "sources must not be empty")
 	}
 
@@ -242,14 +266,12 @@ func (c *Catalog) PatchCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 
 // DeleteCatalog deletes the catalog with the given id.
 // Returns 409 if the catalog still has associated publishers or software.
+// On the root (∅) the count of attached resources is taken from rows with
+// catalog_id IS NULL, since root resources are never tied to the row's UUID.
 func (c *Catalog) DeleteCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 	const errMsg = "can't delete Catalog"
 
 	catalogID, _ := url.PathUnescape(ctx.Params("id"))
-
-	if catalogID == rootCatalogID {
-		return common.Error(fiber.StatusNotFound, errMsg, "Catalog was not found")
-	}
 
 	resolved, err := resolveCatalog(c.db, catalogID)
 	if err != nil {
@@ -271,12 +293,13 @@ func (c *Catalog) DeleteCatalog(ctx *fiber.Ctx) error { //nolint:cyclop
 	if err := c.db.Transaction(func(tran *gorm.DB) error {
 		var publisherCount, softwareCount int64
 
-		if err := tran.Model(&models.Publisher{}).
-			Where("catalog_id = ?", catalog.ID).Count(&publisherCount).Error; err != nil {
+		pubScope := tran.Model(&models.Publisher{}).Scopes(catalogScope(&catalog))
+		if err := pubScope.Count(&publisherCount).Error; err != nil {
 			return err
 		}
 
-		if err := tran.Model(&models.Software{}).Where("catalog_id = ?", catalog.ID).Count(&softwareCount).Error; err != nil {
+		swScope := tran.Model(&models.Software{}).Scopes(catalogScope(&catalog))
+		if err := swScope.Count(&softwareCount).Error; err != nil {
 			return err
 		}
 

--- a/software-catalog-api.oas.yaml
+++ b/software-catalog-api.oas.yaml
@@ -2146,6 +2146,11 @@ components:
           description: >
             Optional alternative user-provided identifier for this Catalog.
             If present, you can use it in place of the Catalog `id` as a path argument.
+            The reserved value `∅` (U+2205, URL-encoded `%E2%88%85`) materializes
+            the implicit root catalog: the row holds the configuration
+            (publishersNamespace, name, scopes, active) but its resources keep
+            being addressed via `catalog_id IS NULL`. Once set to `∅` it cannot
+            be changed via PATCH, and `sources` are not allowed.
           maxLength: 255
           example: 'example-catalog'
         active:
@@ -2185,11 +2190,11 @@ components:
             - 'm49:150'
         sources:
           type: array
-          minItems: 1
           maxItems: 100
           description: >
-            Data sources for this catalog. At least one is
-            required on creation.
+            Data sources for this catalog. At least one is required on
+            creation, except for the root catalog (alternativeId `∅`)
+            where sources are not allowed.
           example:
             - url: 'https://github.com/example-org'
               driver: 'github'


### PR DESCRIPTION
POST /catalogs with alternativeId "∅" creates the configuration row for the implicit root catalog.

PATCH /catalogs/∅ and DELETE /catalogs/∅ now operate on the materialized row. PATCH refuses to change alternativeId away from "∅" and refuses sources. DELETE counts attached resources via IS NULL and returns 409 if any remain.

Also, persist publishersNamespace on POST. It was parsed and validated but silently dropped.