### PR TITLE
feat: stricter validation for publisher CodeHosting URLs

### DIFF
--- a/internal/common/requests.go
+++ b/internal/common/requests.go
@@ -58,7 +58,7 @@ type PublisherPatch struct {
 }
 
 type CodeHosting struct {
-	URL   string `json:"url" validate:"required,url"`
+	URL   string `json:"url" validate:"required,http_url,code_hosting_url"`
 	Group *bool  `json:"group"`
 }
 

--- a/internal/common/validator.go
+++ b/internal/common/validator.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -9,6 +10,13 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/italia/developers-italia-api/internal/jsondecoder"
 )
+
+// hostValidator runs the `fqdn` tag against the host of a candidate URL.
+// Kept as a separate instance so we don't recurse into the struct-level
+// validator we are already running.
+//
+//nolint:gochecknoglobals // shared validator instance for the host check
+var hostValidator = validator.New()
 
 const (
 	tagPosition      = 2
@@ -27,6 +35,8 @@ func ValidateStruct(validateStruct any) []ValidationError {
 	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
 		return strings.SplitN(fld.Tag.Get("json"), ",", tagPosition)[0]
 	})
+
+	_ = validate.RegisterValidation("code_hosting_url", validateCodeHostingURL)
 
 	var validationErrors []ValidationError
 
@@ -79,6 +89,19 @@ func ValidateRequestEntity(ctx *fiber.Ctx, request any, errorMessage string) err
 	return nil
 }
 
+// validateCodeHostingURL rejects publisher CodeHosting URLs that point at
+// non public hosts. The "http_url" tag already vets the scheme and overall
+// shape. Here we only require the host to be a real FQDN, which
+// excludes IP literals and single label hosts.
+func validateCodeHostingURL(fl validator.FieldLevel) bool {
+	parsed, err := url.Parse(fl.Field().String())
+	if err != nil {
+		return false
+	}
+
+	return hostValidator.Var(parsed.Hostname(), "fqdn") == nil
+}
+
 func GenerateErrorDetails(validationErrors []ValidationError) string {
 	var errors []string
 
@@ -94,6 +117,8 @@ func GenerateErrorDetails(validationErrors []ValidationError) string {
 			errors = append(errors, validationError.Field+" does not meet its size limits (too long)")
 		case "gt":
 			errors = append(errors, validationError.Field+" does not meet its size limits (too few items)")
+		case "code_hosting_url":
+			errors = append(errors, validationError.Field+" is not a valid public http(s) URL")
 		default:
 			errors = append(errors, validationError.Field+" is invalid")
 		}

--- a/internal/common/validator_test.go
+++ b/internal/common/validator_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateCodeHostingURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		url   string
+		valid bool
+	}{
+		{"https github", "https://github.com/foo/bar", true},
+		{"http public", "http://example.org/repo", true},
+		{"empty", "", true},
+		{"userinfo with password", "https://user:pass@example.org/repo", true},
+		{"userinfo no password", "https://user@example.org/repo", true},
+
+		{"ftp scheme", "ftp://example.org/repo", false},
+		{"file scheme", "file:///etc/passwd", false},
+		{"git scheme", "git://example.org/repo.git", false},
+
+		{"localhost host", "https://localhost/repo", false},
+		{"localhost trailing dot", "https://localhost./repo", false},
+		{"LOCALHOST trailing dot", "https://LOCALHOST./repo", false},
+		{"loopback ipv4", "https://127.0.0.1/repo", false},
+		{"loopback ipv6", "https://[::1]/repo", false},
+		{"unspecified", "https://0.0.0.0/repo", false},
+
+		{"private 10/8", "https://10.0.0.1/repo", false},
+		{"private 172.16/12", "https://172.16.0.1/repo", false},
+		{"private 192.168/16", "https://192.168.1.1/repo", false},
+		{"link local v4", "https://169.254.1.1/repo", false},
+		{"link local v6", "https://[fe80::1]/repo", false},
+
+		{"missing host", "https:///repo", false},
+		{"malformed", "::not a url::", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := struct {
+				URL string `validate:"omitempty,http_url,code_hosting_url"`
+			}{URL: tt.url}
+
+			errs := ValidateStruct(payload)
+
+			if tt.valid {
+				assert.Empty(t, errs, "expected %q to validate", tt.url)
+			} else {
+				assert.NotEmpty(t, errs, "expected %q to fail", tt.url)
+			}
+		})
+	}
+}

--- a/publishers_test.go
+++ b/publishers_test.go
@@ -775,7 +775,7 @@ func TestPublishersEndpoints(t *testing.T) {
 			},
 			expectedCode:        422,
 			expectedContentType: "application/problem+json",
-			expectedBody:        `{"title":"can't update Publisher","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"url","value":"INVALID_URL"}]}`,
+			expectedBody:        `{"title":"can't update Publisher","detail":"invalid format: url is invalid","status":422,"validationErrors":[{"field":"url","rule":"http_url","value":"INVALID_URL"}]}`,
 		},
 		{
 			description: "PATCH publishers with empty body",


### PR DESCRIPTION
Reject URLs that point at non public hosts.

Fix #101.