### PR TITLE
fix: preserve existing namespaces in analysis PATCH

### DIFF
--- a/catalogs_test.go
+++ b/catalogs_test.go
@@ -1281,4 +1281,38 @@ func TestCatalogAnalysisDBChecks(t *testing.T) {
 		assert.Equal(t, float64(75), badges["score"])
 		assertRFC3339(t, badges["t"])
 	})
+
+	t.Run("PATCH analysis preserves existing namespaces", func(t *testing.T) {
+		loadFixtures(t)
+
+		req1, err := newTestRequest("PATCH", "/v1/catalogs/"+italiaID+"/analysis", strings.NewReader(`{"ns-one": {"v": 1, "score": 90}}`))
+		require.NoError(t, err)
+		req1.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/merge-patch+json"},
+		}
+
+		res1, err := app.Test(req1, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res1.StatusCode)
+
+		req2, err := newTestRequest("PATCH", "/v1/catalogs/"+italiaID+"/analysis", strings.NewReader(`{"ns-two": {"v": 2, "grade": "A"}}`))
+		require.NoError(t, err)
+		req2.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/merge-patch+json"},
+		}
+
+		res2, err := app.Test(req2, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+
+		raw := dbValue(t, "catalogs", "analysis", "id", italiaID)
+
+		var analysis map[string]interface{}
+		require.NoError(t, json.NewDecoder(strings.NewReader(raw)).Decode(&analysis))
+
+		assert.Contains(t, analysis, "ns-one", "ns-one namespace must survive a subsequent PATCH of a different namespace")
+		assert.Contains(t, analysis, "ns-two", "ns-two namespace must be present after second PATCH")
+	})
 }

--- a/internal/handlers/software.go
+++ b/internal/handlers/software.go
@@ -447,7 +447,8 @@ func injectTouchedAnalysis(
 		return nil, err //nolint:wrapcheck
 	}
 
-	result := make(common.AnalysisData, len(updated))
+	result := make(common.AnalysisData, len(original)+len(updated))
+	maps.Copy(result, original)
 	maps.Copy(result, updated)
 	maps.Copy(result, injected)
 

--- a/software_test.go
+++ b/software_test.go
@@ -1647,6 +1647,42 @@ func TestSoftwareAnalysisDBChecks(t *testing.T) {
 		assertRFC3339(t, badges["t"])
 	})
 
+	t.Run("PATCH analysis preserves existing namespaces", func(t *testing.T) {
+		loadFixtures(t)
+
+		const softwareID = "59803fb7-8eec-4fe5-a354-8926009c364a"
+
+		req1, err := newTestRequest("PATCH", "/v1/software/"+softwareID+"/analysis", strings.NewReader(`{"ns-one": {"v": 1, "score": 90}}`))
+		require.NoError(t, err)
+		req1.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/merge-patch+json"},
+		}
+
+		res1, err := app.Test(req1, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res1.StatusCode)
+
+		req2, err := newTestRequest("PATCH", "/v1/software/"+softwareID+"/analysis", strings.NewReader(`{"ns-two": {"v": 2, "grade": "A"}}`))
+		require.NoError(t, err)
+		req2.Header = map[string][]string{
+			"Authorization": {goodToken},
+			"Content-Type":  {"application/merge-patch+json"},
+		}
+
+		res2, err := app.Test(req2, -1)
+		require.NoError(t, err)
+		assert.Equal(t, 200, res2.StatusCode)
+
+		raw := dbValue(t, "software", "analysis", "id", softwareID)
+
+		var analysis map[string]interface{}
+		require.NoError(t, json.NewDecoder(strings.NewReader(raw)).Decode(&analysis))
+
+		assert.Contains(t, analysis, "ns-one", "ns-one namespace must survive a subsequent PATCH of a different namespace")
+		assert.Contains(t, analysis, "ns-two", "ns-two namespace must be present after second PATCH")
+	})
+
 }
 
 func TestSoftwareDeleteDBChecks(t *testing.T) {


### PR DESCRIPTION
The result was built from the request body only, so namespaces already in the DB but absent from the request were silently dropped.