### PR TITLE
ci: pin supply chain and make builds reproducible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       go-deps:
         patterns:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,16 @@ on:
 jobs:
   linters:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
-      - uses: golangci/golangci-lint-action@v9.2.1
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.11.3
           args: --timeout 3m

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -7,9 +7,14 @@ jobs:
   publiccode_yml_validation:
     runs-on: ubuntu-latest
     name: publiccode.yml validation
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-    - uses: actions/checkout@v6
-    - uses: italia/publiccode-parser-action@v1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: italia/publiccode-parser-action@21086c73ec0563e14c6748787efa1b34b025ad8c # v1
       with:
         publiccode: 'publiccode.yml'
         comment-on-pr: true

--- a/.github/workflows/publish-staging-docker-image.yml
+++ b/.github/workflows/publish-staging-docker-image.yml
@@ -19,11 +19,13 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
-      - uses: actions/checkout@v6
+          cache: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # All history, required for goreleaser
           fetch-depth: 0
       - # FIXME: goreleaser should already take care of the login
@@ -36,7 +38,7 @@ jobs:
       - # Tag with a temporary valid semantic version. This is required by goreleaser.
         run: git tag v0-main-$(git rev-parse --short HEAD)
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           version: v2.15.2
           args: release --config .goreleaser.staging.yaml

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -10,12 +10,14 @@ jobs:
   release_chart:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Get version
         id: get_version
         run: echo "::set-output name=version::${GITHUB_REF_NAME#helm/}"
       - name: Push chart to GitHub Container Registry
-        uses: appany/helm-oci-chart-releaser@v0.5.0
+        uses: appany/helm-oci-chart-releaser@d94988c92bed2e09c6113981f15f8bb495d10943 # v0.5.0
         with:
           name: developers-italia-api
           repository: ${{ github.repository }}/charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,21 +3,22 @@ on:
     tags:
       - v*
 
-permissions:
-  # To upload archives as GitHub Releases
-  contents: write
-  # To push Docker images to GitHub
-  packages: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
-      - uses: actions/checkout@v6
+          cache: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           # All history, required for goreleaser
           fetch-depth: 0
       - # For TagBody, TagSubject or TagContents fields in goreleaser's templates
@@ -28,9 +29,13 @@ jobs:
         run: echo "$GITHUB_TOKEN" | docker login ghcr.io -u docker --password-stdin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
+        id: goreleaser
         with:
           version: v2.15.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: dist/checksums.txt

--- a/.github/workflows/spectral.yaml
+++ b/.github/workflows/spectral.yaml
@@ -18,6 +18,8 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - run: curl --fail -L https://github.com/italia/api-oas-checker-rules/releases/download/1.1/spectral-full.yml > .spectral.yml
 
       # Get the custom function required by spectral-full

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          online-audits: false
+          min-severity: medium
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+
+  reproducibility:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: 1.25.x
+      - name: Build twice and compare digests
+        run: |
+          SOURCE_DATE_EPOCH=0 CGO_ENABLED=0 GOFLAGS=-mod=readonly \
+            go build -trimpath -ldflags="-s -w -buildid=" -o /tmp/build1 .
+          SOURCE_DATE_EPOCH=0 CGO_ENABLED=0 GOFLAGS=-mod=readonly \
+            go build -trimpath -ldflags="-s -w -buildid=" -o /tmp/build2 .
+          sha256sum /tmp/build1 /tmp/build2
+          cmp /tmp/build1 /tmp/build2 && echo "Reproducible build confirmed"

--- a/.github/workflows/tests-postgresql.yml
+++ b/.github/workflows/tests-postgresql.yml
@@ -16,9 +16,12 @@ jobs:
   tests-postgresql:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     services:
       db:
-        image: postgres:14
+        image: postgres:14@sha256:a209aced4fa19381231fae4d9a4c5816f7691294f13572f8bddc082ba32e1c7c
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test
@@ -31,10 +34,13 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
       - run: go test -race ./...
         env:
           DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/test?sslmode=disable"
+          GOFLAGS: -mod=readonly

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -15,11 +15,16 @@ on:
 jobs:
   tests-sqlite:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: 1.25.x
       - run: go test -race ./...
         env:
+          GOFLAGS: -mod=readonly
           DATABASE_DSN: "file:/tmp/test.db"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,10 @@ builds:
   - binary: software-catalog-api
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
-     - -s -w
+      - -s -w -buildid=
     goos:
       - linux
 archives:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -3,7 +3,7 @@
 #
 # Goreleaser takes care of building the binary.
 #
-FROM alpine:3
+FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
 
 COPY software-catalog-api /usr/local/bin/software-catalog-api
 RUN ln -s /usr/local/bin/software-catalog-api /usr/local/bin/developers-italia-api


### PR DESCRIPTION
All GitHub Actions, the alpine:3.22 base image, and the postgres test service are now pinned to SHAs.

-trimpath and -buildid= make the binary reproducible: two builds from the same source now produce the same sha256. Release artifacts get provenance via actions/attest-build-provenance.