### PR TITLE
Fix: DB migration error of `logs` due to type mismatch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,5 +31,5 @@ dockers:
  -
    dockerfile: Dockerfile.goreleaser
    image_templates:
-     - "ghcr.io/thisisnttheway/developers-italia-api:{{ .Tag }}"
-     - "ghcr.io/thisisnttheway/developers-italia-api:latest"
+     - "ghcr.io/italia/developers-italia-api:{{ .Tag }}"
+     - "ghcr.io/italia/developers-italia-api:latest"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,5 +31,5 @@ dockers:
  -
    dockerfile: Dockerfile.goreleaser
    image_templates:
-     - "ghcr.io/italia/developers-italia-api:{{ .Tag }}"
-     - "ghcr.io/italia/developers-italia-api:latest"
+     - "ghcr.io/thisisnttheway/developers-italia-api:{{ .Tag }}"
+     - "ghcr.io/thisisnttheway/developers-italia-api:latest"

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -38,22 +38,10 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("can't open database: %w", err)
 	}
 
-	modelsToMigrate := []any{
-		&models.Catalog{},
-		&models.CatalogSource{},
-		&models.Publisher{},
-		&models.Event{},
-		&models.CodeHosting{},
-		&models.Software{},
-		&models.SoftwareURL{},
-		&models.Webhook{},
+	if err := migrateModels(database); err != nil {
+		return nil, fmt.Errorf("database migration error: %w", err)
 	}
 
-	for _, m := range modelsToMigrate {
-		if err := database.AutoMigrate(m); err != nil {
-			return nil, fmt.Errorf("can't migrate model %T: %w", m, err)
-		}
-	}
 	// Workaround until #72 (proper migrations): GIN index on analysis for
 	// per-namespace queries. SQLite doesn't support GIN, PostgreSQL only.
 	if !strings.HasPrefix(connection, "file:") {
@@ -63,16 +51,36 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 		}
 	}
 
+	return database, nil
+}
+
+// Migrate all models.
+func migrateModels(database *gorm.DB) error {
+	for _, model := range []any{
+		&models.Catalog{},
+		&models.CatalogSource{},
+		&models.Publisher{},
+		&models.Event{},
+		&models.CodeHosting{},
+		&models.Software{},
+		&models.SoftwareURL{},
+		&models.Webhook{},
+	} {
+		if err := database.AutoMigrate(model); err != nil {
+			return fmt.Errorf("can't migrate %T: %w", model, err)
+		}
+	}
+
 	// Migrate logs only if there is no "entity" column yet, which should mean when the database
 	// is empty.
 	// This is a workaround for https://github.com/go-gorm/gorm/issues/5534 where GORM
 	// fails to migrate an existing generated column on PostgreSQL if it already exists.
 	var entity sql.NullString
 	if database.Raw("SELECT entity FROM logs LIMIT 1").Scan(&entity).Error != nil {
-		if err = database.AutoMigrate(&models.Log{}); err != nil {
-			return nil, fmt.Errorf("can't migrate model \"Log\": %w", err)
+		if err := database.AutoMigrate(&models.Log{}); err != nil {
+			return fmt.Errorf("can't migrate model \"Log\": %w", err)
 		}
 	}
 
-	return database, nil
+	return nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -37,7 +38,7 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("can't open database: %w", err)
 	}
 
-	if err = database.AutoMigrate(
+	modelsToMigrate := []any{
 		&models.Catalog{},
 		&models.CatalogSource{},
 		&models.Publisher{},
@@ -46,10 +47,13 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 		&models.Software{},
 		&models.SoftwareURL{},
 		&models.Webhook{},
-	); err != nil {
-		return nil, fmt.Errorf("can't migrate database: %w", err)
 	}
 
+	for _, m := range modelsToMigrate {
+		if err := database.AutoMigrate(m); err != nil {
+			return nil, fmt.Errorf("can't migrate model %T: %w", m, err)
+		}
+	}
 	// Workaround until #72 (proper migrations): GIN index on analysis for
 	// per-namespace queries. SQLite doesn't support GIN, PostgreSQL only.
 	if !strings.HasPrefix(connection, "file:") {
@@ -63,10 +67,10 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 	// is empty.
 	// This is a workaround for https://github.com/go-gorm/gorm/issues/5534 where GORM
 	// fails to migrate an existing generated column on PostgreSQL if it already exists.
-	var entity string
+	var entity sql.NullString
 	if database.Raw("SELECT entity FROM logs LIMIT 1").Scan(&entity).Error != nil {
 		if err = database.AutoMigrate(&models.Log{}); err != nil {
-			return nil, fmt.Errorf("can't migrate database: %w", err)
+			return nil, fmt.Errorf("can't migrate model \"Log\": %w", err)
 		}
 	}
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -54,7 +54,6 @@ func NewDatabase(connection string) (*gorm.DB, error) {
 	return database, nil
 }
 
-// Migrate all models.
 func migrateModels(database *gorm.DB) error {
 	for _, model := range []any{
 		&models.Catalog{},


### PR DESCRIPTION
In a DB where `logs.entity` contains (pretty much exclusively) NULL values:
```
app=> SELECT COUNT(*) AS null_entities
FROM logs
WHERE entity IS NULL;

 null_entities 
---------------
           213
(1 row)
```

This code will cause a panic:
https://github.com/italia/developers-italia-api/blob/876ba6453151ca95aa350aca04759ab890ca7580/internal/database/database.go#L71-L76

`database.Raw().Scan()` will try to scan type `NULL` into `string`, which cannot work:  
```
sql: Scan error on column index 0, name "entity":
converting NULL to string is unsupported

SELECT entity FROM logs LIMIT 1
``` 

As such, `...Scan().Error != nil` evaluates `true`, making `database.AutoMigrate()` execute, thus invalidating the workaround.  
This then fails due to the GORM issue mentioned in the comment above this code block:
```
syntax error at or near "GENERATED" (SQLSTATE 42601)
```

### Changes
- `var entity` is now an `sql.Nullstring` which can accept `NULL`.  
- Logging is improved such that it's now easier to understand which migration has failed.
- Bundling all DB migrations into `migrateModels()` due to linter complaints.

Note that I've based this fix on tag `v1.3.0`.