### PR TITLE
ci: read the Go version from go.mod

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.3

--- a/.github/workflows/publish-staging-docker-image.yml
+++ b/.github/workflows/publish-staging-docker-image.yml
@@ -19,15 +19,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: 1.25.x
-          cache: false
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # All history, required for goreleaser
           fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
       - # FIXME: goreleaser should already take care of the login
         # (see https://github.com/goreleaser/goreleaser/blame/02a3486d4ba59505113a57b438ae567351ed3dab/scripts/entrypoint.sh#L17)
         # but it doesn't work for some reason.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: 1.25.x
-          cache: false
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # All history, required for goreleaser
           fetch-depth: 0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
       - # For TagBody, TagSubject or TagContents fields in goreleaser's templates
         run: git fetch --force --tags
       - # FIXME: goreleaser should already take care of the login

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - name: Build twice and compare digests
         run: |
           SOURCE_DATE_EPOCH=0 CGO_ENABLED=0 GOFLAGS=-mod=readonly \

--- a/.github/workflows/tests-postgresql.yml
+++ b/.github/workflows/tests-postgresql.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - run: go test -race ./...
         env:
           DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/test?sslmode=disable"

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.25.x
+          go-version-file: go.mod
       - run: go test -race ./...
         env:
           GOFLAGS: -mod=readonly


### PR DESCRIPTION
Hardcoded versions in the workflows drift from the go directive.
Let setup-go read go.mod so a Go bump happens in one place.
