### PR TITLE
ci: make the reproducibility gate able to fail

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -39,15 +39,30 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # goreleaser reads the tag history
+          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - name: Build twice and compare digests
+          cache: false
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
+        with:
+          version: v2.15.2
+          install-only: true
+      - name: Build the release artifact with goreleaser
+        run: goreleaser build --snapshot --clean --single-target -o /tmp/goreleaser-build
+        env:
+          # The newest tag may well be a helm/* one, which goreleaser
+          # cannot parse as semver.
+          GORELEASER_CURRENT_TAG: v0.0.0
+
+      - name: Rebuild from source and compare digests
         run: |
-          SOURCE_DATE_EPOCH=0 CGO_ENABLED=0 GOFLAGS=-mod=readonly \
-            go build -trimpath -ldflags="-s -w -buildid=" -o /tmp/build1 .
-          SOURCE_DATE_EPOCH=0 CGO_ENABLED=0 GOFLAGS=-mod=readonly \
-            go build -trimpath -ldflags="-s -w -buildid=" -o /tmp/build2 .
-          sha256sum /tmp/build1 /tmp/build2
-          cmp /tmp/build1 /tmp/build2 && echo "Reproducible build confirmed"
+          cp -a . /tmp/src-elsewhere
+          cd /tmp/src-elsewhere
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOAMD64=v1 \
+            go build -trimpath -ldflags="-s -w -buildid=" -o /tmp/plain-build .
+          sha256sum /tmp/goreleaser-build /tmp/plain-build
+          cmp /tmp/goreleaser-build /tmp/plain-build \
+            && echo "Reproducible build confirmed"


### PR DESCRIPTION
It built twice in the same directory, so it passed no matter what.