### PR TITLE
chore: pin the development image by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # See Dockerfile.goreleaser for the image published on release or staging.
 #
 
-FROM golang:1.25 as base
+FROM golang:1.25@sha256:cbff9d1a9041b316010f2da6b701b6c0d597718cb90928c85eb597334a0d23d4 AS base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-euxc"]
 


### PR DESCRIPTION
The tag stays in the FROM line so it is still readable, and everyone building locally gets the same base image instead of whatever golang:1.25 points at that day.