### PR TITLE
chore: drop air from the development image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,4 @@ SHELL ["/bin/bash", "-o", "pipefail", "-euxc"]
 
 WORKDIR /opt/app/api
 
-ENV AIR_SHA256 3842f9a86304e06f68f61555ce303cb426b450a7be8ee14020cbd149a68008d0
-
-RUN export GO_BINPATH="$(go env GOPATH)/bin" \
-    && echo $GO_BINPATH \
-    && curl -sSfL -o "$GO_BINPATH/air" https://github.com/cosmtrek/air/releases/download/v1.40.2/air_1.40.2_linux_amd64 \
-    && echo "$AIR_SHA256 $GO_BINPATH/air" | sha256sum --check --strict \
-    && chmod +x "$GO_BINPATH/air"
-
-CMD ["air"]
+CMD ["go", "run", "."]

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@
 
 ## Development
 
-The application uses [Air](https://github.com/cosmtrek/air) for live-reloading
-in the development environment.
-
 To start developing:
 
 1. Clone the repo
@@ -61,8 +58,6 @@ Docker Compose will bring up the app and PostgreSQL containers.
 
 Wait until the Docker logs explicitly say the API is up and you can use its
 endpoints at `http://localhost:3000/v1/`.
-
-The application will automatically reload when a change is made.
 
 ## Configuration
 


### PR DESCRIPTION
Live reload was a third party binary.

Compose already mounts the source, so restarting the container picks up changes without extra tooling.