### PR TITLE
ci: check the module cache against go.sum before the tests

### DIFF
--- a/.github/workflows/tests-postgresql.yml
+++ b/.github/workflows/tests-postgresql.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      - run: go mod verify
       - run: go test -race ./...
         env:
           DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/test?sslmode=disable"

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      - run: go mod verify
       - run: go test -race ./...
         env:
           GOFLAGS: -mod=readonly


### PR DESCRIPTION
The test jobs downloaded the dependencies and ran straight into the
suite, so a module whose content no longer matched its recorded hash
would only surface as a confusing compile.
