### PR TITLE
docker: drop the obsolete compose version key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   api:
     ports:


### PR DESCRIPTION
Compose v2 ignores the top level version attribute and warns about it
on every invocation, so anyone bringing the local stack up saw a
warning before the first line of output.
