### PR TITLE
docker: keep local state out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+
+.env
+
+test.db
+test.db-shm
+test.db-wal
+
+dist/
+tmp/


### PR DESCRIPTION
Building the development image sent the whole working tree to the
daemon, git history and any local .env or SQLite test database
included, for a Dockerfile that copies nothing out of it.

The release image is unaffected, since goreleaser builds it from a
directory holding only the binary.
