### PR TITLE
chore: rename the OAS file and repository links to open-catalog-api

### DIFF
--- a/.github/workflows/spectral.yaml
+++ b/.github/workflows/spectral.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: bfabio/spectral-action@5af95a6a2985901bd5e689c663b4f93c660f0d2c
         id: lint
         with:
-          file_glob: software-catalog-api.oas.yaml
+          file_glob: open-catalog-api.oas.yaml
           spectral_ruleset: .spectral.yml
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!-- markdownlint-disable no-inline-html -->
 
-<h1 align="center">Software Catalog API</h1>
+<h1 align="center">Open Catalog API</h1>
 
 <p align="center">
-  <img width="200" src=".github/logo.png" alt="software-catalog-api logo">
+  <img width="200" src=".github/logo.png" alt="open-catalog-api logo">
 </p>
 
 <p align="center">
@@ -11,7 +11,7 @@
     <img src="https://www.bestpractices.dev/projects/14158/badge">
   </a> 
   
-  <img alt="License" src="https://img.shields.io/github/license/italia/developers-italia-api?color=brightgreen">
+  <img alt="License" src="https://img.shields.io/github/license/italia/open-catalog-api?color=brightgreen">
 </p>
 
 <div align="center">
@@ -23,7 +23,7 @@
 </div>
 
 <p align="center">
-  <strong>Software Catalog API</strong> is a RESTful API for public software catalogs.
+  <strong>Open Catalog API</strong> is a RESTful API for public software catalogs.
   It powers national open source catalogs for public administrations:
 </p>
 
@@ -64,7 +64,7 @@ You can configure the API with environment variables:
   and a token with the built-in subcommand:
 
   ```console
-  developers-italia-api token create
+  open-catalog-api token create
   ```
 
   Pass `--key` to use an existing key, `--sub` to identify the caller,
@@ -85,9 +85,9 @@ You can configure the API with environment variables:
 This project exists also thanks to your contributions! Here is a list of people
 who already contributed to this repository:
 
-<a href="https://github.com/italia/developers-italia-api/graphs/contributors">
+<a href="https://github.com/italia/open-catalog-api/graphs/contributors">
   <img
-  src="https://contributors-img.web.app/image?repo=italia/developers-italia-api"
+  src="https://contributors-img.web.app/image?repo=italia/open-catalog-api"
   />
 </a>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ patched, so upgrade to the latest tag before reporting a problem.
 ## Reporting a vulnerability
 
 Report security vulnerabilities via [GitHub private vulnerability
-reporting](https://github.com/italia/developers-italia-api/security/advisories/new).
+reporting](https://github.com/italia/open-catalog-api/security/advisories/new).
 The report stays private between you and the maintainers until a fix is
 released.
 

--- a/open-catalog-api.oas.yaml
+++ b/open-catalog-api.oas.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
-  title: Software Catalog API
+  title: Open Catalog API
   version: 1.0.0
-  x-summary: Software Catalog API
+  x-summary: Open Catalog API
   description: |
     REST API for public software catalogs.
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -15,7 +15,7 @@ description:
       - Containerization support
       - Helm chart available
     longDescription: |
-      **software-catalog-api** is a RESTful API for public software catalogs.
+      **open-catalog-api** is a RESTful API for public software catalogs.
       It powers developers.italia.it and can be deployed as a standalone
       instance for any public software catalog.
     shortDescription: |-
@@ -46,7 +46,7 @@ maintenance:
   contacts:
     - name: Fabio Bonelli
   type: community
-name: software-catalog-api
+name: open-catalog-api
 platforms:
   - web
 dependsOn:
@@ -55,4 +55,4 @@ dependsOn:
       optional: true
 softwareType: standalone/backend
 softwareVersion: v1.0.0
-url: "https://github.com/italia/developers-italia-api"
+url: "https://github.com/italia/open-catalog-api"


### PR DESCRIPTION
See italia/developers-italia-api#270.